### PR TITLE
Add ai-foundations: one model call, measured end to end

### DIFF
--- a/ai-foundations/AiFoundations.csproj
+++ b/ai-foundations/AiFoundations.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Lab01</RootNamespace>
+    <AssemblyName>ai-foundations</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      Deliberately minimal. We do NOT reference the Azure OpenAI SDK or the
+      Agent Framework here, because the entire point of this lab is to see the
+      raw HTTP that those libraries wrap. Auth is a single api-key header.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.Development.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/ai-foundations/Experiments.cs
+++ b/ai-foundations/Experiments.cs
@@ -1,0 +1,826 @@
+using System.Text.Json;
+
+namespace Lab01;
+
+/// <summary>
+/// Seven experiments. Each one isolates a single fact about model calls that
+/// you will rely on for the rest of your career. Run them in order.
+/// </summary>
+internal sealed class Experiments(RawModelClient client, double priceIn, double priceOut)
+{
+    /// <summary>Recorded by experiment 5 so experiment 8 can compare against physics.</summary>
+    public double LastMeasuredTpotMs { get; private set; }
+    // ======================================================================
+    // 1. What actually goes on the wire
+    // ======================================================================
+    public async Task TheWireAsync()
+    {
+        Ui.Header(1, "What actually goes on the wire");
+
+        Msg[] messages =
+        [
+            Msg.System("You are terse. One sentence maximum."),
+            Msg.User("What is the capital of France?"),
+        ];
+
+        var body = RawModelClient.BuildBody(messages, maxTokens: 50);
+
+        Console.WriteLine("\n  >>> REQUEST BODY -- this is 100% of what you send:\n");
+        Ui.Json(body);
+
+        var (doc, elapsed, bytes) = await client.SendAsync(body);
+        var root = doc.RootElement;
+        var choice = root.GetProperty("choices")[0];
+
+        Console.WriteLine("\n  >>> RESPONSE BODY -- the parts that matter:\n");
+        Ui.Json(new
+        {
+            message = new
+            {
+                role = choice.GetProperty("message").GetProperty("role").GetString(),
+                content = choice.GetProperty("message").GetProperty("content").GetString(),
+            },
+            finish_reason = choice.GetProperty("finish_reason").GetString(),
+            // Pass the raw JsonElement through, not our C# record -- otherwise
+            // PascalCase property names would leak into output that claims to
+            // show you the wire. The real field names are snake_case.
+            usage = root.GetProperty("usage"),
+        });
+
+        Console.WriteLine($"\n  request size: {bytes} bytes    wall clock: {elapsed.TotalMilliseconds:F0} ms");
+
+        // Now deliberately truncate, to show the failure mode.
+        var truncated = RawModelClient.BuildBody(
+            [Msg.User("List the 20 largest countries by area, with their sizes.")],
+            maxTokens: 40);
+        var (doc2, _, _) = await client.SendAsync(truncated);
+        var c2 = doc2.RootElement.GetProperty("choices")[0];
+
+        Console.WriteLine("\n  >>> Same API, max_tokens=40, a question needing far more:\n");
+        Console.WriteLine("  " + c2.GetProperty("message").GetProperty("content").GetString()?.Replace("\n", "\n  "));
+        Console.WriteLine($"\n  finish_reason = \"{c2.GetProperty("finish_reason").GetString()}\"   <-- LOOK AT THIS");
+
+        Ui.Note("""
+        THE WHOLE INTEGRATION IS A JSON POST.
+
+        No session. No connection. No handle. No object living on a server with
+        your name on it. You sent an array of messages; you got an array back.
+        HTTP 200 both times.
+
+        Two fields deserve permanent attention:
+
+          finish_reason -- WHY generation stopped.
+              "stop"   = the model decided it was done. Good.
+              "length" = you hit max_tokens. YOUR OUTPUT IS TRUNCATED.
+
+              That second call returned HTTP 200 with a confident, well-formed,
+              INCOMPLETE answer. No exception. No error field. Nothing in your
+              monitoring stack fires. If you parse that as JSON downstream, it
+              fails; if you show it to a user, they see a sentence that stops.
+
+              This is your first taste of the one genuinely new failure mode:
+              the system fails by lying quietly rather than by erroring.
+
+          usage -- what you are billed for, and the only honest measure of how
+              expensive your prompt design actually is.
+        """);
+    }
+
+    // ======================================================================
+    // 2. The model has no memory
+    // ======================================================================
+    public async Task NoMemoryAsync()
+    {
+        Ui.Header(2, "The model has no memory (proof)");
+
+        Console.WriteLine("\n  Call A -- tell it a number:\n");
+        var a = await AskAsync([Msg.User("Remember this number: 8829. Reply with just: OK")], 20);
+        Console.WriteLine("    -> " + a);
+
+        Console.WriteLine("\n  Call B -- brand new request, ask for it back:\n");
+        var b = await AskAsync([Msg.User("What number did I ask you to remember?")], 60);
+        Console.WriteLine("    -> " + b);
+
+        Console.WriteLine("\n  Call C -- same question, but WE resend the history:\n");
+        var c = await AskAsync(
+        [
+            Msg.User("Remember this number: 8829. Reply with just: OK"),
+            Msg.Assistant("OK"),
+            Msg.User("What number did I ask you to remember?"),
+        ], 60);
+        Console.WriteLine("    -> " + c);
+
+        Ui.Note("""
+        Call B failed. Call C worked. Same model, same question, seconds apart.
+
+        The only difference is that in C we put the history back into the request
+        ourselves. "Memory" is not a model feature. It is a client-side data
+        structure that YOU resend on every single call.
+
+        Look closely at call C: we WROTE the assistant's previous reply. Nothing
+        verified it. Nothing checked the model ever said "OK". You can put words
+        in the model's mouth, and several prompting techniques do exactly that.
+
+        What this costs you in production:
+          a 50-turn conversation resends all 50 turns on turn 51.
+          Cost and latency grow with CONVERSATION length, not message length.
+          Every agent framework's "memory" feature is managing this array.
+        """);
+    }
+
+    // ======================================================================
+    // 3. Tokens are not words
+    // ======================================================================
+    public async Task TokensAsync()
+    {
+        Ui.Header(3, "Tokens are not words (and you pay per token)");
+
+        (string Label, string Text)[] samples =
+        [
+            ("plain English",   "The quick brown fox jumps over the lazy dog."),
+            ("C# code",         "var x = arr.Where(i => i.Id != null).ToList();"),
+            ("a GUID",          "550e8400-e29b-41d4-a716-446655440000"),
+            ("French",          "L'accord commercial international est signe."),
+            ("Hindi",           "\u0905\u0928\u094D\u0924\u0930\u094D\u0930\u093E\u0937\u094D\u091F\u094D\u0930\u0940\u092F \u0935\u094D\u092F\u093E\u092A\u093E\u0930 \u0938\u092E\u091D\u094C\u0924\u093E \u0939\u0938\u094D\u0924\u093E\u0915\u094D\u0937\u0930\u093F\u0924\u0964"),
+            ("Japanese",        "\u56FD\u969B\u8CBF\u6613\u5354\u5B9A\u304C\u7F72\u540D\u3055\u308C\u307E\u3057\u305F\u3002"),
+            ("base64 blob",     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"),
+            ("indented JSON",   "{\n  \"a\": 1,\n  \"b\": [2, 3, 4]\n}"),
+            ("minified JSON",   "{\"a\":1,\"b\":[2,3,4]}"),
+            ("(one character)", "."),
+        ];
+
+        Console.WriteLine();
+        Console.WriteLine($"  {"sample",-18}{"chars",6}{"tokens",8}{"chars/token",14}");
+        Ui.Rule();
+
+        var results = new List<(string Label, int Chars, int Tokens, double Ratio)>();
+
+        foreach (var (label, text) in samples)
+        {
+            // max_tokens=1 keeps output cost negligible; prompt_tokens is what we want.
+            var body = RawModelClient.BuildBody([Msg.User(text)], maxTokens: 1);
+            var (doc, _, _) = await client.SendAsync(body);
+            var u = Usage.From(doc.RootElement.GetProperty("usage"));
+            var ratio = (double)text.Length / u.PromptTokens;
+            results.Add((label, text.Length, u.PromptTokens, ratio));
+            Console.WriteLine($"  {label,-18}{text.Length,6}{u.PromptTokens,8}{ratio,14:F2}");
+        }
+
+        Ui.Rule();
+
+        // Report what YOUR tokenizer actually did, rather than asserting folklore.
+        var best = results.MaxBy(r => r.Ratio);
+        var worst = results.MinBy(r => r.Ratio);
+        var english = results.First(r => r.Label == "plain English");
+        var indented = results.First(r => r.Label == "indented JSON");
+        var minified = results.First(r => r.Label == "minified JSON");
+
+        Console.WriteLine($"""
+
+              cheapest per character : {best.Label} ({best.Ratio:F2} chars/token)
+              most expensive         : {worst.Label} ({worst.Ratio:F2} chars/token)
+              spread                 : {best.Ratio / worst.Ratio:F1}x
+
+              JSON indentation tax   : {indented.Tokens} tokens indented vs {minified.Tokens} minified
+                                       for the same data ({(double)indented.Tokens / minified.Tokens:F1}x)
+            """);
+
+        Ui.Note($"""
+        Every row has a different chars-per-token ratio. Same API, same billing
+        rate, wildly different cost per character.
+
+        The tokenizer was built by BPE (Byte Pair Encoding): it repeatedly merged
+        the most frequent adjacent byte pairs in its training corpus into single
+        tokens. It is LEARNED COMPRESSION, not a language rule. So the ratio for
+        any given text depends entirely on whether merges for it were learned.
+
+        WHAT THIS MEANS IN PRACTICE, AND WHY YOU SHOULD NOT TRUST FOLKLORE HERE:
+
+        The commonly repeated claim is "non-English costs 2-3x more". That was
+        true of older tokenizers (cl100k, ~100k vocab). Modern ones (o200k,
+        ~200k vocab) doubled the vocabulary and spent much of it on multilingual
+        merges. On your run above, French may well have come out CHEAPER than
+        English -- French accent-free prose compresses very well.
+
+        But the advantage is uneven and script-dependent:
+
+          Latin-script European  -> now roughly at parity with English
+          Devanagari, CJK, Thai  -> still noticeably worse per character,
+                                    though far better than two years ago
+
+        The honest rule is: DO NOT ASSUME. Measure it, for your model, the way
+        this experiment just did. Tokenizer behaviour changes with every model
+        generation and it changes your bill.
+
+        WHAT HAS NOT CHANGED, AND WON'T:
+
+          * Entropy is incompressible. GUIDs, hashes, and base64 approach
+            1 char/token no matter how large the vocabulary gets, because no
+            merge can exist for a random sequence. If you paste base64 images or
+            hashes into prompts, you pay near-worst-case rates.
+
+          * Structural whitespace is pure waste. Look at the indentation tax
+            above -- identical data, and the pretty-printed version costs
+            noticeably more. Minifying JSON in prompts is one of the few
+            completely free optimisations available to you.
+
+          * Per-message overhead is real. A single "." costs ~8 tokens, because
+            the chat template wraps every message in role markers you never see:
+
+                <|im_start|>user\n.<|im_end|>\n<|im_start|>assistant\n
+
+            You pay that per message. A conversation of 50 short messages pays
+            it 50 times, before a single word of content.
+        """);
+    }
+
+    // ======================================================================
+    // 4. Where the money goes
+    // ======================================================================
+    public async Task CostAsync()
+    {
+        Ui.Header(4, "Where the money goes");
+
+        var policyDoc = "Below is the company travel policy.\n\n" + string.Concat(
+            Enumerable.Repeat(
+                "Employees must submit receipts within 30 days of travel. Meal caps " +
+                "are $75 domestic and $100 international. Hotel caps are $250 and " +
+                "$400 per night respectively. Airfare requires prior approval. ", 45));
+
+        (string Label, string Prompt, int MaxTokens)[] cases =
+        [
+            ("short in, short out", "Reply with exactly: hi", 10),
+            ("short in, long out",  "Write a detailed 250-word explanation of CPU caching.", 400),
+            ("long in, short out",  policyDoc + "\n\nWhat is the domestic meal cap?", 20),
+        ];
+
+        Console.WriteLine();
+        Console.WriteLine($"  {"case",-21}{"in",7}{"out",7}{"$ in",12}{"$ out",12}{"$ total",12}");
+        Ui.Rule();
+
+        double grand = 0;
+        foreach (var (label, prompt, maxT) in cases)
+        {
+            var body = RawModelClient.BuildBody([Msg.User(prompt)], maxTokens: maxT);
+            var (doc, _, _) = await client.SendAsync(body);
+            var u = Usage.From(doc.RootElement.GetProperty("usage"));
+
+            var cin = u.PromptTokens / 1_000_000.0 * priceIn;
+            var cout = u.CompletionTokens / 1_000_000.0 * priceOut;
+            grand += cin + cout;
+
+            Console.WriteLine($"  {label,-21}{u.PromptTokens,7}{u.CompletionTokens,7}" +
+                              $"{cin,12:F6}{cout,12:F6}{cin + cout,12:F6}");
+        }
+
+        Ui.Rule();
+        Console.WriteLine($"  {"total for this experiment",-21}{"",14}{"",24}{grand,12:F6}");
+
+        Ui.Note($"""
+        Output tokens cost {priceOut / priceIn:F0}x more than input tokens, per token.
+
+        That ratio is not arbitrary pricing strategy. It is physics showing up on
+        an invoice:
+
+          INPUT  is processed in ONE parallel pass over the whole prompt (prefill).
+                 The GPU is doing big matrix multiplies. It is COMPUTE-bound and
+                 highly efficient.
+
+          OUTPUT is generated ONE TOKEN AT A TIME (decode). Each token requires
+                 reading the ENTIRE model's weights out of GPU memory. It is
+                 MEMORY-BANDWIDTH-bound and desperately inefficient -- roughly
+                 0.3% of the GPU's peak compute is actually used.
+
+        So both levers matter, but differently:
+
+          reduce input  -> better retrieval, cache-aware prompt layout, minify
+          reduce output -> ask for terse/structured output, set max_tokens honestly
+
+        Now extrapolate to an agent. A 10-step agent loop does NOT cost 10x a
+        single call. Each step resends a context that grew by the previous step's
+        output. Cost grows roughly QUADRATICALLY with step count. This is why
+        agent bills surprise teams who reasoned linearly.
+        """);
+    }
+
+    // ======================================================================
+    // 5. TTFT vs TPOT
+    // ======================================================================
+    public async Task LatencyAsync()
+    {
+        Ui.Header(5, "TTFT vs TPOT -- why the first token is slow");
+
+        const string task = "Count from 1 to 40, comma separated. Numbers only.";
+
+        // Two long prompts, same length, one crucial difference:
+        //   cacheable   -- identical prefix every run, so the provider can reuse
+        //                  its KV cache and skip most of the prefill.
+        //   uncacheable -- random prefix every run, so prefill must actually run.
+        // The gap between them IS prefix caching, measured.
+        var fixedPrefix = string.Concat(Enumerable.Repeat(
+            "Here is background material which you should completely ignore. ", 350));
+        // Guid.NewGuid(), not new Random(seed). A seeded RNG produces the SAME
+        // "random" prefix on every program run, so the provider's cache -- which
+        // lives for minutes -- happily served it and reported 98% cached. The
+        // control needs to be unique across runs, not merely across iterations.
+        string RandomPrefix() => string.Concat(Enumerable.Range(0, 115).Select(_ =>
+            $"Reference note {Guid.NewGuid()} which you should ignore. "));
+
+        // A single sample is worthless here. Server load, routing, and cache
+        // hits move TTFT by hundreds of milliseconds run to run -- easily enough
+        // to reverse the result and "disprove" something true. We take medians.
+        // This is the same instinct you already have about benchmarking.
+        const int Repeats = 5;
+
+        Console.WriteLine($"\n  sampling each variant {Repeats}x (medians reported) ...\n");
+
+        var shortRuns = new List<StreamResult>();
+        var cachedRuns = new List<StreamResult>();
+        var uncachedRuns = new List<StreamResult>();
+
+        for (var i = 0; i < Repeats; i++)
+        {
+            shortRuns.Add(await client.StreamAsync(
+                RawModelClient.BuildBody([Msg.User(task)], maxTokens: 250, stream: true)));
+
+            cachedRuns.Add(await client.StreamAsync(
+                RawModelClient.BuildBody([Msg.User(fixedPrefix + "\n\n" + task)],
+                    maxTokens: 250, stream: true)));
+
+            uncachedRuns.Add(await client.StreamAsync(
+                RawModelClient.BuildBody([Msg.User(RandomPrefix() + "\n\n" + task)],
+                    maxTokens: 250, stream: true)));
+
+            Console.WriteLine($"    run {i + 1}/{Repeats}   short {shortRuns[^1].Ttft.TotalMilliseconds,6:F0}" +
+                              $"   long-cached {cachedRuns[^1].Ttft.TotalMilliseconds,6:F0}" +
+                              $"   long-random {uncachedRuns[^1].Ttft.TotalMilliseconds,6:F0}   ms TTFT");
+        }
+
+        var shortTtft = Median(shortRuns.Select(r => r.Ttft.TotalMilliseconds));
+        var cachedTtft = Median(cachedRuns.Select(r => r.Ttft.TotalMilliseconds));
+        var uncachedTtft = Median(uncachedRuns.Select(r => r.Ttft.TotalMilliseconds));
+        var shortTpot = Median(shortRuns.Select(r => r.TpotMs));
+
+        Console.WriteLine();
+        Console.WriteLine($"  {"variant",-16}{"in tok",9}{"TTFT ms",11}{"TTFT spread",18}");
+        Ui.Rule();
+        Line("short", shortRuns, shortTtft);
+        Line("long, cacheable", cachedRuns, cachedTtft);
+        Line("long, random", uncachedRuns, uncachedTtft);
+        Ui.Rule();
+
+        var shortTok = shortRuns[^1].Usage?.PromptTokens ?? 1;
+        var cachedTok = cachedRuns[^1].Usage?.PromptTokens ?? 1;
+        var uncachedTok = uncachedRuns[^1].Usage?.PromptTokens ?? 1;
+
+        // Azure only attaches usage.latency_checkpoint to NON-streaming
+        // responses -- the streaming usage chunk omits it. So repeat each
+        // variant without streaming purely to harvest the server's own clock.
+        // (A detail you only ever find by reading the raw response, which is
+        //  the entire moral of this experiment.)
+        // NOTE the Func here rather than a fixed message array. The first version
+        // of this code built the random prompt ONCE and sent it three times --
+        // so probes 2 and 3 hit the cache created by probe 1, and the
+        // "uncacheable" control reported ~98% cached. The experiment was
+        // measuring the effect it was supposed to control for. Regenerating the
+        // prefix per call is the fix.
+        var srvShort = await ProbeAsync(() => [Msg.User(task)]);
+        var srvCached = await ProbeAsync(() => [Msg.User(fixedPrefix + "\n\n" + task)]);
+        var srvRandom = await ProbeAsync(() => [Msg.User(RandomPrefix() + "\n\n" + task)]);
+
+        async Task<List<Usage>> ProbeAsync(Func<Msg[]> messages)
+        {
+            var list = new List<Usage>();
+            for (var i = 0; i < 3; i++)
+            {
+                var (doc, _, _) = await client.SendAsync(
+                    RawModelClient.BuildBody(messages(), maxTokens: 60));
+                if (doc.RootElement.TryGetProperty("usage", out var u))
+                    list.Add(Usage.From(u));
+            }
+            return list;
+        }
+
+        var noiseFloor = shortRuns.Select(r => r.Ttft.TotalMilliseconds).Max()
+                       - shortRuns.Select(r => r.Ttft.TotalMilliseconds).Min();
+
+        Console.WriteLine($"""
+
+              Measurement noise on the SHORT prompt alone: +/-{noiseFloor:F0} ms.
+              That is your floor. Nothing smaller than it is a result -- and
+              prefill for a few thousand tokens is far smaller than it.
+            """);
+
+        // ------------------------------------------------------------------
+        // The client-side numbers above cannot resolve prefill. But the server
+        // has been telling us the truth in a field most people never read:
+        // usage.latency_checkpoint. Those timings are taken INSIDE the service,
+        // so the network is excluded entirely.
+        // ------------------------------------------------------------------
+        var haveServer = srvShort.Any(u => u.HasServerTiming);
+
+        if (haveServer)
+        {
+            Console.WriteLine("""
+
+                  ==========================================================================
+                  NOW LOOK AT WHAT THE SERVER TOLD US ALL ALONG
+                  ==========================================================================
+
+                  The response carries usage.latency_checkpoint -- timings measured inside
+                  the service, with your network path excluded. Same requests, honest clock.
+                """);
+
+            Console.WriteLine();
+            Console.WriteLine($"  {"variant",-16}{"in tok",9}{"cached",9}{"engine TTFT",13}{"pre-inf",10}{"client TTFT",13}");
+            Ui.Rule();
+            ServerLine("short", srvShort, shortTtft);
+            ServerLine("long, cacheable", srvCached, cachedTtft);
+            ServerLine("long, random", srvRandom, uncachedTtft);
+            Ui.Rule();
+
+            var engShort = Median(srvShort.Select(u => u.EngineTtftMs));
+            var engCached = Median(srvCached.Select(u => u.EngineTtftMs));
+            var engRandom = Median(srvRandom.Select(u => u.EngineTtftMs));
+            var srvShortTok = srvShort[^1].PromptTokens;
+            var srvCachedTok = srvCached[^1].PromptTokens;
+            var srvRandomTok = srvRandom[^1].PromptTokens;
+            var cachedHit = MedianAll(srvCached.Select(u => (double)u.CachedTokens));
+            var randomHit = MedianAll(srvRandom.Select(u => (double)u.CachedTokens));
+            var engRatio = engShort > 0 ? engRandom / engShort : 0;
+
+            Console.WriteLine($"""
+
+                  PREFILL, MEASURED PROPERLY
+
+                      {srvShortTok,6} tokens ->{engShort,7:F0} ms of engine prefill
+                      {srvRandomTok,6} tokens ->{engRandom,7:F0} ms          ({engRatio:F1}x)
+
+                  There it is. {srvRandomTok / Math.Max(srvShortTok, 1)}x the tokens, {engRatio:F1}x the prefill time. Prefill
+                  scales with prompt length exactly as the theory says. It was never
+                  invisible -- it was just {engRandom:F0} ms hiding under {noiseFloor:F0} ms of network jitter.
+
+                  PREFIX CACHING, MEASURED PROPERLY
+
+                      long, cacheable : {cachedHit:F0} of {srvCachedTok} prompt tokens served from cache
+                      long, random    : {randomHit:F0} of {srvRandomTok} prompt tokens served from cache
+
+                  No stopwatch involved. The provider states outright how many tokens it
+                  did not have to re-process, and bills those at the cached rate. For
+                  gpt-4.1-mini that is $0.10 per 1M instead of $0.40.
+
+                  Two prompts of near-identical length ({srvCachedTok} vs {srvRandomTok} tokens), doing
+                  the same task. The only difference is whether the prefix repeats
+                  byte-for-byte -- and the engine clock agrees with the token counts:
+
+                      long, cacheable :{engCached,6:F0} ms of prefill
+                      long, random    :{engRandom,6:F0} ms of prefill   ({(engCached > 0 ? engRandom / engCached : 0):F1}x)
+
+                  Same length, same task, {(engCached > 0 ? engRandom / engCached : 0):F1}x the prefill work. One volatile
+                  token near the front -- a timestamp, a request ID, a session GUID --
+                  would collapse that 98% hit rate to zero and move the random row's
+                  numbers onto your bill. Nothing would error. Nobody would notice.
+                """);
+
+            Console.WriteLine($"""
+
+                  AND NOW THE REAL POINT
+
+                  Compare the columns. Engine prefill is tens of milliseconds. Your
+                  client-side TTFT is over a second. Well over 90% of what you call
+                  "model latency" is pre-inference routing, queueing, TLS and network.
+
+                  If you were tasked with making this endpoint feel faster, the model is
+                  the wrong place to look. That conclusion is invisible from the client
+                  and obvious from one field in the response body.
+
+                  THE HABIT WORTH KEEPING: before building a harness to measure something
+                  through a noisy channel, read the entire response. Providers ship far
+                  more telemetry than their SDKs surface, and every SDK that maps
+                  responses onto a tidy typed object throws fields like this away.
+                  Ours nearly did too -- experiment 1 was printing a C# record instead of
+                  the wire, and this block was simply not visible.
+                """);
+        }
+        else
+        {
+            Console.WriteLine("""
+
+                  This provider does not return server-side timings, so prefill stays
+                  buried under network noise here. Knowing your noise floor BEFORE you
+                  claim an effect is the transferable skill; most published LLM latency
+                  comparisons skip it, which is why they disagree with each other.
+                """);
+        }
+
+        // Prefer the server's honest time-between-tokens over our own, which the
+        // network may have made meaningless. Experiment 8 consumes this.
+        var serverTbt = Median(srvShort.Select(u => u.EngineTbtMs));
+        LastMeasuredTpotMs = serverTbt > 0 ? serverTbt
+                           : shortRuns[^1].LooksBuffered ? 0
+                           : shortTpot;
+
+        var buffered = shortRuns[^1].LooksBuffered;
+        if (buffered)
+        {
+            var clientTpot = Median(shortRuns.Select(r => r.TpotMs));
+            var verdict = serverTbt > 0
+                ? $"""
+                  And here is the correction, from the same server telemetry:
+
+                      your client measured   {clientTpot,6:F2} ms per token
+                      the engine reports     {serverTbt,6:F2} ms per token   <-- the real one
+
+                  Roughly {(clientTpot > 0 ? serverTbt / clientTpot : 0):F0}x wrong, in the direction that flatters the system.
+                  Note which way the error went: the broken measurement made things
+                  look FASTER. Measurement bugs are rarely neutral -- they tend to
+                  favour whatever you were hoping to see, which is precisely why you
+                  check them hardest when the result is good news.
+                """
+                : """
+                  This provider gives no server-side per-token timing either, so use
+                  the bandwidth-derived figure in experiment 8 instead.
+                """;
+
+            Console.WriteLine($"""
+
+                  ------------------------------------------------------------------
+                  YOUR TPOT MEASUREMENT WAS IMPOSSIBLE. HERE IS THE PROOF.
+
+                  Most inter-chunk gaps came back under 0.5 ms. Real decode needs a
+                  full forward pass per token -- milliseconds, not microseconds.
+                  Sub-millisecond gaps cannot happen.
+
+                  What did happen: the provider, a proxy, or your TLS stack buffered
+                  many tokens and flushed them in one network write. You were timing
+                  your own socket reads, not the GPU.
+
+                {verdict}
+                  ------------------------------------------------------------------
+                """);
+        }
+
+        Ui.Note("""
+        TTFT and TPOT are tracked separately because they have OPPOSITE
+        bottlenecks. This is the most important latency fact in the field, and it
+        is why a single "latency" number is always misleading.
+
+          TTFT  = PREFILL.  Entire prompt processed in one parallel pass.
+                            COMPUTE-bound. Scales with prompt length.
+
+          TPOT  = DECODE.   One token per forward pass, each requiring a full
+                            read of model weights from HBM.
+                            MEMORY-BANDWIDTH-bound. Barely cares about prompt
+                            length -- only about model size.
+
+          Total latency = TTFT + (TPOT x output tokens)
+
+        THE CACHED-VS-RANDOM ROWS ARE THE PRACTICAL LESSON -- even when, as often
+        happens over the public internet, the timing effect is buried in noise.
+
+        Both long prompts do the same task. The only difference is whether the
+        prefix repeats. A repeated prefix lets the provider reuse the KV cache it
+        already built, and it is BILLED at the cached-input rate: for
+        gpt-4.1-mini that is $0.10 per 1M instead of $0.40. Four times cheaper,
+        for a change that is purely about ORDERING.
+
+        Billing is the reliable signal here, not your stopwatch. The cost saving
+        shows up in the invoice whether or not you can time it from a laptop.
+
+            Put stable content FIRST (system prompt, policy, few-shot examples).
+            Put volatile content LAST (user input, timestamps, IDs).
+
+        One volatile token near the front invalidates the cache for everything
+        after it. Teams routinely put a timestamp or request ID at the top of a
+        prompt and silently lose the entire benefit -- and nothing errors, so
+        nobody notices until someone reads the bill.
+
+        Also note the TTFT spread column. Run-to-run variance on a hosted
+        endpoint is large -- you share hardware with strangers. Any latency claim
+        from a single sample, yours or a vendor's, is noise.
+
+        Other consequences worth internalising:
+
+          * A long prompt hurts perceived responsiveness, not throughput.
+          * A bigger model hurts TPOT much more than TTFT.
+          * Optimising one can worsen the other -- batching more requests raises
+            TTFT while improving throughput. A real trade serving teams make.
+          * Streaming makes NOTHING faster. It changes which number the user
+            perceives, from total time to TTFT. A UX trick, and a good one.
+        """);
+
+        static void Line(string label, List<StreamResult> runs, double median)
+        {
+            var ms = runs.Select(r => r.Ttft.TotalMilliseconds).ToArray();
+            var tok = runs[^1].Usage?.PromptTokens ?? 0;
+            var spread = $"{ms.Min():F0}-{ms.Max():F0} ms";
+            Console.WriteLine($"  {label,-16}{tok,9}{median,11:F0}{spread,18}");
+        }
+
+        static void ServerLine(string label, List<Usage> us, double clientTtft)
+        {
+            if (us.Count == 0) return;
+            Console.WriteLine($"  {label,-16}{us[^1].PromptTokens,9}" +
+                              $"{MedianAll(us.Select(u => (double)u.CachedTokens)),9:F0}" +
+                              $"{Median(us.Select(u => u.EngineTtftMs)),13:F0}" +
+                              $"{Median(us.Select(u => u.PreInferenceMs)),10:F0}" +
+                              $"{clientTtft,13:F0}");
+        }
+
+        // Median() drops zeros, which is right for latencies (a zero means the
+        // field was absent) and WRONG for token counts, where zero is the most
+        // meaningful value there is -- it means nothing was cached.
+        static double MedianAll(IEnumerable<double> xs)
+        {
+            var a = xs.OrderBy(x => x).ToArray();
+            return a.Length == 0 ? 0
+                 : a.Length % 2 == 1 ? a[a.Length / 2]
+                 : (a[a.Length / 2 - 1] + a[a.Length / 2]) / 2;
+        }
+
+        static double Median(IEnumerable<double> xs)
+        {
+            var a = xs.Where(x => x > 0).OrderBy(x => x).ToArray();
+            return a.Length == 0 ? 0
+                 : a.Length % 2 == 1 ? a[a.Length / 2]
+                 : (a[a.Length / 2 - 1] + a[a.Length / 2]) / 2;
+        }
+    }
+
+    // ======================================================================
+    // 6. What streaming actually is
+    // ======================================================================
+    public async Task StreamingShapeAsync()
+    {
+        Ui.Header(6, "What streaming actually looks like");
+
+        var r = await client.StreamAsync(RawModelClient.BuildBody(
+            [Msg.User("Reply with exactly this and nothing else: Hello there, my friend.")],
+            maxTokens: 40, stream: true));
+
+        Console.WriteLine("\n  Raw chunks in arrival order:\n");
+        Console.WriteLine("    " + string.Join(" | ",
+            r.Chunks.Select(c => "\"" + c.Replace("\n", "\\n") + "\"")));
+
+        Console.WriteLine($"\n  {r.Chunks.Count} chunks  ->  \"{r.Text}\"");
+        Console.WriteLine($"  finish_reason = {r.FinishReason}");
+
+        Console.WriteLine("\n  Arrival timeline (ms since request sent):\n");
+        for (var i = 0; i < Math.Min(r.ArrivalsMs.Count, 12); i++)
+        {
+            var gap = i == 0 ? r.ArrivalsMs[0] : r.ArrivalsMs[i] - r.ArrivalsMs[i - 1];
+            var bar = new string('#', Math.Min((int)(gap / 2), 50));
+            Console.WriteLine($"    {r.ArrivalsMs[i],7:F0}  (+{gap,6:F0})  {bar} {Escape(r.Chunks[i])}");
+        }
+
+        // The short reply above is very likely to arrive in one buffered flush.
+        // Rather than assert that "longer generations often reveal the real
+        // gaps", test it: ask for a long generation and look again.
+        var longR = await client.StreamAsync(RawModelClient.BuildBody(
+            [Msg.User("Count slowly from 1 to 120, one number per line, numbers only.")],
+            maxTokens: 400, stream: true));
+
+        var gaps = Enumerable.Range(1, Math.Max(0, longR.ArrivalsMs.Count - 1))
+                             .Select(i => longR.ArrivalsMs[i] - longR.ArrivalsMs[i - 1])
+                             .ToArray();
+        var flushes = gaps.Count(g => g >= 0.5);
+
+        Console.WriteLine($"""
+
+              Now the same thing with a LONG generation ({longR.Chunks.Count} chunks):
+
+                chunks              : {longR.Chunks.Count}
+                distinct flushes    : {flushes}   (gaps >= 0.5 ms)
+                chunks per flush    : {(flushes > 0 ? (double)longR.Chunks.Count / flushes : longR.Chunks.Count),0:F1}
+                median non-zero gap : {(gaps.Where(g => g >= 0.5).OrderBy(g => g).ToArray() is { Length: > 0 } nz ? nz[nz.Length / 2] : 0),0:F1} ms
+            """);
+
+        var longBuffered = longR.LooksBuffered;
+        var firstChunks = string.Join(", ",
+            r.Chunks.Take(6).Select(c => "\"" + c.Replace("\n", "\\n") + "\""));
+
+        var timingComment = r.LooksBuffered
+            ? $"""
+        BUT LOOK AT YOUR TIMELINE: the gaps are almost all +0 ms.
+
+        Those tokens arrived in the same millisecond. That cannot be decode --
+        each token needs its own forward pass, which takes milliseconds. The
+        provider generated a run of tokens, then flushed them in ONE network
+        write.
+
+        So you are seeing the correct TOKEN BOUNDARIES (which is the point of
+        this experiment) but NOT the true generation timing.
+
+        {(longBuffered
+            ? "The long generation was buffered too -- look at 'chunks per flush'\nabove. The response came back in a handful of network writes, each\ncarrying dozens of tokens. You are measuring the provider's flush\npolicy, not the GPU."
+            : "The long generation, however, was NOT buffered -- look at its median\nnon-zero gap above. That is much closer to genuine per-token decode\ntime. Buffering depends on response length and provider policy, which\nis exactly why one measurement is never enough.")}
+
+        You cannot fix this from the client. But you do not have to: experiment 5
+        pulls the engine's own per-token timing out of usage.latency_checkpoint,
+        and experiment 8 derives an independent figure from memory bandwidth.
+        Two honest sources beat one convenient stopwatch.
+        """
+            : """
+        Look at the timeline. The first gap is large -- that is prefill, the whole
+        prompt processed in one pass. Every gap after it is small and remarkably
+        uniform -- that is decode, doing the same fixed amount of work per token,
+        over and over. You are watching the two phases separate on screen.
+        """;
+
+        Ui.Note($"""
+        The chunks are ragged: {firstChunks} ...
+
+        That is not a network artifact. THOSE ARE THE TOKENS. Streaming delivers
+        them over Server-Sent Events -- an ordinary HTTP response held open,
+        emitting "data:" lines until it sends "data: [DONE]".
+
+        {timingComment}
+
+        Two things the API is quietly doing for you here:
+
+          1. DETOKENIZATION. Token IDs -> bytes -> text, buffered until a complete
+             UTF-8 character exists. That buffering is why chunk boundaries look
+             arbitrary and why an emoji may arrive as one chunk after a pause.
+
+          2. HIDING TOKEN IDS ENTIRELY. The model never saw your string; it saw
+             an array of integers. The tokenizer runs SERVER-SIDE. That is the
+             whole reason you send text and not IDs -- and the reason you cannot
+             know your exact token count before sending.
+        """);
+
+        static string Escape(string s) => "\"" + s.Replace("\n", "\\n") + "\"";
+    }
+
+    // ======================================================================
+    // 7. Non-determinism
+    // ======================================================================
+    public async Task NonDeterminismAsync()
+    {
+        Ui.Header(7, "Same input, different output");
+
+        Msg[] prompt = [Msg.User("Invent a name for a coffee shop. Reply with the name only.")];
+
+        var hot = await SampleAsync(prompt, temperature: 1.0, n: 5);
+        Console.WriteLine("\n  temperature = 1.0, five identical requests:\n");
+        foreach (var s in hot) Console.WriteLine("    -> " + s);
+        Console.WriteLine($"\n    distinct: {hot.Distinct().Count()} / {hot.Count}");
+
+        var cold = await SampleAsync(prompt, temperature: 0.0, n: 5);
+        Console.WriteLine("\n  temperature = 0.0 (greedy), five identical requests:\n");
+        foreach (var s in cold) Console.WriteLine("    -> " + s);
+        Console.WriteLine($"\n    distinct: {cold.Distinct().Count()} / {cold.Count}");
+
+        Ui.Note("""
+        This is the property that invalidates every testing instinct you have.
+
+        temperature scales the logits before sampling. At 1.0 you sample from the
+        distribution; at 0 you take the argmax every step. So temperature=0 is
+        MUCH more repeatable -- but it is still not a guarantee, because
+        floating-point reduction order on a GPU depends on batch composition, and
+        your request is batched with strangers' requests. Different neighbours,
+        different summation order, different last decimal place, occasionally a
+        different argmax. Once one token differs, the rest of the sequence can
+        diverge completely.
+
+        You cannot write Assert.Equal against this. Not "should not", CANNOT.
+
+        That single fact is why evaluation is a DISCIPLINE rather than a test
+        suite, and it is the doorway to the most valuable skill in this repo.
+
+        The right question is never "is the output correct?"
+        It is: "over N runs, what fraction were correct, and what do the
+                failures have in common?"
+
+        That metric has a name -- consistency@k -- and building a harness for it
+        is the natural next project after this one. Your distributed-systems
+        instincts transfer directly: this is flaky-test triage and availability
+        math, not machine learning.
+
+        Note also what experiment 5 showed you about measurement. Before you can
+        say "this prompt is more reliable than that one", you need to know your
+        noise floor -- how much the answer moves when NOTHING changes. Same
+        discipline, applied to correctness instead of latency.
+        """);
+    }
+
+    // ------------------------------------------------------------------
+    private async Task<string> AskAsync(Msg[] messages, int maxTokens)
+    {
+        var (doc, _, _) = await client.SendAsync(RawModelClient.BuildBody(messages, maxTokens));
+        return doc.RootElement.GetProperty("choices")[0]
+            .GetProperty("message").GetProperty("content").GetString()?.Trim() ?? "";
+    }
+
+    private async Task<List<string>> SampleAsync(Msg[] prompt, double temperature, int n)
+    {
+        var results = new List<string>();
+        for (var i = 0; i < n; i++)
+        {
+            var body = RawModelClient.BuildBody(prompt, maxTokens: 20, temperature: temperature);
+            var (doc, _, _) = await client.SendAsync(body);
+            results.Add(doc.RootElement.GetProperty("choices")[0]
+                .GetProperty("message").GetProperty("content").GetString()?.Trim() ?? "");
+        }
+        return results;
+    }
+}

--- a/ai-foundations/HardwareMath.cs
+++ b/ai-foundations/HardwareMath.cs
@@ -1,0 +1,281 @@
+namespace Lab01;
+
+/// <summary>
+/// Experiments 8 and 9 need no API calls at all -- they are arithmetic.
+///
+/// This is deliberate. The most important fact in inference is a ratio you can
+/// compute on paper, and once you have computed it yourself you will never
+/// again be confused about why decode is slow, why batching exists, or why the
+/// industry started fighting over memory instead of compute.
+/// </summary>
+internal sealed class HardwareMath(double measuredTpotMs)
+{
+    // ---- Reference hardware. Edit these to model a different GPU. ----
+    private const double H100MemBandwidthGBs = 3350.0;   // HBM3, GB/s
+    private const double H100PeakTFlopsBf16 = 989.0;     // dense, with sparsity off
+    private const double A100MemBandwidthGBs = 2039.0;
+    private const double A100PeakTFlopsBf16 = 312.0;
+
+    // ---- Reference model: 70B parameters at FP16 (2 bytes each) ----
+    private const double ParamsBillions = 70.0;
+    private const double BytesPerParam = 2.0;
+
+    // ======================================================================
+    // 8. Why decode is memory-bound -- the roofline
+    // ======================================================================
+    public void Roofline()
+    {
+        Ui.Header(8, "Why decode is memory-bound (pure arithmetic, no API)");
+
+        var modelBytes = ParamsBillions * 1e9 * BytesPerParam;
+        var modelGb = modelBytes / 1e9;
+
+        Console.WriteLine($"""
+
+              Model:  {ParamsBillions:F0}B parameters at FP16 -> {modelGb:F0} GB of weights.
+
+              ARITHMETIC INTENSITY (AI) = FLOPs performed / bytes moved from memory.
+              It is the single number that decides whether you are compute-bound
+              or memory-bound. Every GPU has a RIDGE POINT -- the AI at which it
+              stops being starved for data and starts being limited by math.
+            """);
+
+        Console.WriteLine();
+        Console.WriteLine($"  {"GPU",-8}{"bandwidth GB/s",18}{"peak TFLOP/s",15}{"ridge point",16}");
+        Ui.Rule();
+        Ridge("H100", H100MemBandwidthGBs, H100PeakTFlopsBf16);
+        Ridge("A100", A100MemBandwidthGBs, A100PeakTFlopsBf16);
+        Ui.Rule();
+
+        Console.WriteLine($"""
+
+              Now the two phases, for a {ParamsBillions:F0}B model.
+
+              DECODE, batch size 1 -- generating ONE token:
+                bytes moved  : {modelGb:F0} GB   (the ENTIRE model, every token)
+                FLOPs        : ~2 x params = {2 * ParamsBillions:F0} GFLOP
+                AI           = {2 * ParamsBillions * 1e9 / modelBytes:F1} FLOP/byte
+            """);
+
+        var decodeAi = 2 * ParamsBillions * 1e9 / modelBytes;
+        var h100Ridge = H100PeakTFlopsBf16 * 1e12 / (H100MemBandwidthGBs * 1e9);
+        var utilisation = decodeAi / h100Ridge * 100;
+
+        Console.WriteLine($"""
+
+              An H100 needs AI >= {h100Ridge:F0} to saturate its compute.
+              Decode delivers AI = {decodeAi:F1}.
+
+              You are running at roughly {utilisation:F2}% of the machine's compute
+              capability. The GPU is almost entirely idle, waiting on memory.
+
+              PREFILL, {1000} prompt tokens:
+                bytes moved  : {modelGb:F0} GB   (the same weights, ONCE)
+                FLOPs        : ~2 x params x tokens = {2 * ParamsBillions * 1000 / 1000:F0} TFLOP
+                AI           = {2 * ParamsBillions * 1e9 * 1000 / modelBytes:F0} FLOP/byte
+            """);
+
+        var prefillAi = 2 * ParamsBillions * 1e9 * 1000 / modelBytes;
+        Console.WriteLine($"""
+
+              Prefill AI = {prefillAi:F0}, which is well past the ridge point of {h100Ridge:F0}.
+              Prefill is COMPUTE-bound. Decode is MEMORY-bound. Same model, same
+              GPU, same request -- opposite bottlenecks, minutes apart.
+
+              THIS IS THE WHOLE STORY. Everything else in inference systems is a
+              consequence of this one table.
+            """);
+
+        // ---- Predict token rate from bandwidth alone ----
+        var predictedTokPerSec = H100MemBandwidthGBs * 1e9 / modelBytes;
+        var predictedTpotMs = 1000.0 / predictedTokPerSec;
+
+        Console.WriteLine();
+        Ui.Rule('=');
+        Console.WriteLine("  PREDICTION FROM PHYSICS ALONE");
+        Ui.Rule('=');
+        Console.WriteLine($"""
+
+              If decode really is bandwidth-bound, then token rate should be
+              almost exactly:
+
+                  memory bandwidth / model size
+                = {H100MemBandwidthGBs:F0} GB/s / {modelGb:F0} GB
+                = {predictedTokPerSec:F1} tokens/sec       ({predictedTpotMs:F1} ms per token)
+
+              on a single H100 at batch size 1.
+
+              That is a prediction made with no benchmark, no profiler, and no
+              knowledge of the model architecture beyond its parameter count.
+              Published figures for 70B on a single H100 land in the 20-30 tok/s
+              range. The prediction is close because the model is simple and the
+              bottleneck is real.
+            """);
+
+        if (measuredTpotMs > 0)
+        {
+            // Invert the roofline: if decode is bandwidth-bound then
+            //     TPOT = bytes_moved / bandwidth
+            // so bytes_moved = TPOT x bandwidth. Bytes moved per token is
+            // essentially the size of the weights, which gives a parameter
+            // count for a model whose size nobody has published.
+            var gbPerToken = H100MemBandwidthGBs * (measuredTpotMs / 1000.0);
+            var paramsFp16 = gbPerToken / 2;
+            var paramsFp8 = gbPerToken;
+
+            Console.WriteLine($"""
+
+              ======================================================================
+              NOW RUN IT BACKWARDS ON A MODEL NOBODY HAS TOLD YOU THE SIZE OF
+              ======================================================================
+
+              Experiment 5 got a real per-token figure from the server's own
+              clock: {measuredTpotMs:F1} ms/token.
+
+              If decode is bandwidth-bound, then TPOT = bytes moved / bandwidth,
+              so we can solve for the bytes:
+
+                  bytes per token = {measuredTpotMs:F1} ms x 3350 GB/s = {gbPerToken:F0} GB
+
+              That is roughly the weight footprint of the model serving you.
+              Turn it into a parameter count:
+
+                  if served at FP16 (2 bytes/param) -> ~{paramsFp16:F0}B parameters
+                  if served at FP8  (1 byte/param)  -> ~{paramsFp8:F0}B parameters
+
+              Treat that as an order of magnitude, not a measurement. It assumes
+              H100-class bandwidth, ignores the KV cache reads, and -- most
+              importantly -- your request was BATCHED with strangers'. Batching
+              amortises the weight load across many sequences, which makes the
+              real per-request byte cost lower than this and pushes the estimate
+              UPWARD. So read it as a loose upper bound.
+
+              But sit with what just happened. From one timing field, with no
+              architecture details, no benchmark and no insider information, you
+              bounded the size of a proprietary model to within an order of
+              magnitude -- using nothing but a bandwidth number and division.
+
+              That is what it means for a bottleneck to be REAL rather than
+              incidental. When a system is pinned against physics, the physics
+              tells you about the system.
+            """);
+        }
+
+        Ui.Note("""
+        WHY THIS MATTERS BEYOND TRIVIA
+
+        Every headline in AI infrastructure follows from that ~0.3% number:
+
+          * Why HBM sold out before GPUs did. If decode is bandwidth-bound, the
+            scarce resource is memory bandwidth, not FLOPs. Vendors responded by
+            shipping memory-only refreshes -- the H200 is an H100 with more and
+            faster HBM and identical compute. That product exists because of
+            this ratio.
+
+          * Why quantisation is the highest-leverage optimisation. Halving the
+            bytes per weight nearly halves decode latency, because you are
+            moving half as much memory. It buys speed directly, not just space.
+
+          * Why Mixture-of-Experts models exist. MoE activates only a fraction
+            of parameters per token, so fewer bytes move. It is a bandwidth
+            optimisation wearing an architecture costume.
+
+          * Why everyone is suddenly interested in KV cache. Once weights are
+            handled, the KV cache is the next thing competing for that same
+            scarce bandwidth and capacity.
+        """);
+
+        static void Ridge(string name, double bwGbs, double tflops)
+        {
+            var ridge = tflops * 1e12 / (bwGbs * 1e9);
+            Console.WriteLine($"  {name,-8}{bwGbs,18:F0}{tflops,15:F0}{ridge,13:F0} F/B");
+        }
+    }
+
+    // ======================================================================
+    // 9. Batching -- the escape hatch
+    // ======================================================================
+    public void Batching()
+    {
+        Ui.Header(9, "Batching: the escape hatch (pure arithmetic, no API)");
+
+        var modelBytes = ParamsBillions * 1e9 * BytesPerParam;
+        var h100Ridge = H100PeakTFlopsBf16 * 1e12 / (H100MemBandwidthGBs * 1e9);
+        var tokPerSecTotal = H100MemBandwidthGBs * 1e9 / modelBytes;
+
+        Console.WriteLine($"""
+
+              The key insight: ONE load of the weights can serve MANY requests.
+
+              The weights move from HBM to the compute units once per step,
+              regardless of how many sequences are in the batch. So bytes stay
+              constant while FLOPs multiply by batch size. Arithmetic intensity
+              rises linearly with batch size -- for free.
+            """);
+
+        Console.WriteLine();
+        Console.WriteLine($"  {"batch",8}{"AI (F/B)",12}{"% of ridge",13}{"tok/s total",14}{"tok/s each",13}");
+        Ui.Rule();
+
+        foreach (var b in new[] { 1, 4, 16, 64, 128, 256 })
+        {
+            var ai = 2.0 * ParamsBillions * 1e9 * b / modelBytes;
+            var pctRidge = ai / h100Ridge * 100;
+            var each = tokPerSecTotal;               // per-sequence rate stays ~flat
+            var total = tokPerSecTotal * b;          // aggregate scales with batch
+            var marker = ai >= h100Ridge ? "  <- compute-bound now" : "";
+            Console.WriteLine($"  {b,8}{ai,12:F0}{pctRidge,12:F1}%{total,14:F0}{each,13:F1}{marker}");
+        }
+
+        Ui.Rule();
+
+        Console.WriteLine($"""
+
+              Read the last two columns carefully, because this is the trade that
+              every inference platform is making on your behalf right now:
+
+                tok/s TOTAL  goes up ~linearly with batch size.  (throughput)
+                tok/s EACH   stays roughly flat.                 (your latency)
+
+              So batching is nearly free throughput -- until AI crosses the ridge
+              point at {h100Ridge:F0} F/B, after which you are genuinely compute-bound
+              and further batching starts costing per-request latency.
+            """);
+
+        Ui.Note("""
+        WHAT THIS EXPLAINS
+
+        * WHY YOUR REQUEST IS BATCHED WITH STRANGERS' REQUESTS.
+          At batch 1 a provider wastes 99.7% of the GPU. At batch 128 they are
+          near the ridge. The economics are not close -- serving you alone would
+          cost ~100x more. This is why every hosted API batches, and it is why
+          you cannot get bit-exact reproducibility even at temperature 0:
+          your batch neighbours change the floating-point reduction order.
+
+        * WHY "CONTINUOUS BATCHING" WAS A BREAKTHROUGH.
+          Naive static batching waits for every sequence in the batch to finish.
+          One long generation stalls 127 short ones. Continuous batching evicts
+          finished sequences and admits new ones every single step, keeping the
+          batch full. It is work-stealing for token generation, and it roughly
+          2-4x'd throughput industry-wide.
+
+        * WHY KV CACHE MEMORY IS THE REAL LIMIT.
+          Batching is free throughput, so why not batch 10,000? Because each
+          sequence needs its own KV cache, and KV cache lives in the same HBM as
+          the weights. Your maximum batch size -- and therefore the provider's
+          entire cost structure -- is set by how much KV cache fits in memory.
+
+          That is why PagedAttention mattered so much. By eliminating memory
+          fragmentation it took KV utilisation from ~20-40% to >90%, which
+          directly means a bigger batch, which directly means lower cost per
+          token. A memory-management trick from 1960s operating systems is
+          responsible for a large chunk of the price drop in LLM inference.
+
+        * WHY PREFILL AND DECODE ARE BEING SPLIT ONTO DIFFERENT MACHINES.
+          They have opposite bottlenecks (experiment 8), so co-locating them
+          means one always interferes with the other. Prefill/decode
+          disaggregation puts each phase on hardware suited to it. This is the
+          current frontier of serving architecture.
+        """);
+    }
+}

--- a/ai-foundations/Program.cs
+++ b/ai-foundations/Program.cs
@@ -1,0 +1,239 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Lab01;
+
+/// <summary>
+/// AI FOUNDATIONS -- everything about a model call, in one project, stepped
+/// through one experiment at a time.
+///
+/// No SDK. No agent framework. Raw HTTP, so nothing is hidden from you.
+///
+/// The goal is not to build something. The goal is that afterwards you can
+/// answer all of these from memory:
+///
+///   1. What exactly goes on the wire when I "chat" with a model?
+///   2. Why does the model have no memory?
+///   3. Why do code and GUIDs cost so much more than English?
+///   4. Where does my money actually go?
+///   5. Why is the first token so much slower than the rest?
+///   6. What is streaming really?
+///   7. Why can't I write Assert.Equal against this?
+///   8. Why is decode memory-bound, and why does that explain the whole industry?
+///   9. Why is my request batched with strangers', and why does that cap cost?
+///
+/// Experiments 1-7 make real API calls. 8-9 are pure arithmetic, no calls.
+///
+/// Usage:
+///   dotnet run              run all nine, straight through
+///   dotnet run -- 5         run only experiment 5
+///   dotnet run -- 1 3 5     run a subset
+///   dotnet run -- step      pause between each one
+///   dotnet run -- list      show the menu and exit
+/// </summary>
+internal static class Program
+{
+    private sealed record Step(int N, string Name, string Blurb, Func<Task> Run, bool NeedsApi = true);
+
+    private static async Task<int> Main(string[] args)
+    {
+        var config = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("appsettings.json", optional: true)
+            .AddJsonFile("appsettings.Development.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var endpoint = config["AzureOpenAI:Endpoint"];
+        var deployment = config["AzureOpenAI:Deployment"];
+        var apiVersion = config["AzureOpenAI:ApiVersion"] ?? "2024-10-21";
+        var apiKey = config["AzureOpenAI:ApiKey"];
+        var priceIn = double.TryParse(config["Pricing:PerMillionInputUsd"], out var pi) ? pi : 0.40;
+        var priceOut = double.TryParse(config["Pricing:PerMillionOutputUsd"], out var po) ? po : 1.60;
+
+        var configured = !string.IsNullOrWhiteSpace(endpoint)
+                         && !string.IsNullOrWhiteSpace(deployment)
+                         && !string.IsNullOrWhiteSpace(apiKey)
+                         && !endpoint!.Contains("your-resource");
+
+        var lab = configured
+            ? new Experiments(new RawModelClient(endpoint!, deployment!, apiVersion, apiKey!), priceIn, priceOut)
+            : null;
+
+        Step[] steps =
+        [
+            new(1, "the wire",        "the full JSON request and response, plus silent truncation",
+                () => lab!.TheWireAsync()),
+            new(2, "no memory",       "three calls proving the model forgets everything",
+                () => lab!.NoMemoryAsync()),
+            new(3, "tokens",          "why a GUID costs 4x what English costs",
+                () => lab!.TokensAsync()),
+            new(4, "cost",            "real dollars, and why output costs more than input",
+                () => lab!.CostAsync()),
+            new(5, "latency",         "TTFT vs TPOT -- the most important latency fact there is",
+                () => lab!.LatencyAsync()),
+            new(6, "streaming",       "raw SSE chunks and an arrival timeline",
+                () => lab!.StreamingShapeAsync()),
+            new(7, "non-determinism", "same prompt, different answers -- why tests break",
+                () => lab!.NonDeterminismAsync()),
+            new(8, "roofline",        "why decode is memory-bound   [no API needed]",
+                () => { new HardwareMath(lab?.LastMeasuredTpotMs ?? 0).Roofline(); return Task.CompletedTask; },
+                NeedsApi: false),
+            new(9, "batching",        "why you are batched with strangers   [no API needed]",
+                () => { new HardwareMath(lab?.LastMeasuredTpotMs ?? 0).Batching(); return Task.CompletedTask; },
+                NeedsApi: false),
+        ];
+
+        if (args.Contains("list"))
+        {
+            PrintMenu(steps);
+            return 0;
+        }
+
+        var numeric = args.Where(a => int.TryParse(a, out _)).Select(int.Parse).ToHashSet();
+        var selected = numeric.Count > 0 ? steps.Where(s => numeric.Contains(s.N)).ToArray() : steps;
+
+        if (selected.Length == 0)
+        {
+            Console.WriteLine("\n  No experiment matched. Valid numbers: 1-9.");
+            PrintMenu(steps);
+            return 1;
+        }
+
+        if (!configured)
+        {
+            var offline = selected.Where(s => !s.NeedsApi).ToArray();
+            if (offline.Length == 0)
+            {
+                PrintMissingConfig();
+                return 1;
+            }
+
+            Console.WriteLine("""
+
+                  No API credentials configured, so skipping experiments 1-7.
+                  Running the arithmetic-only experiments instead.
+                  See appsettings.Development.json.template to enable the rest.
+                """);
+            selected = offline;
+        }
+
+        Ui.Banner(
+            "AI FOUNDATIONS -- ONE MODEL CALL, COMPLETELY UNDERSTOOD",
+            "",
+            $"deployment : {(configured ? deployment : "(not configured)")}",
+            $"pricing    : ${priceIn}/M in, ${priceOut}/M out   (edit appsettings.json)",
+            "",
+            $"running    : {string.Join(", ", selected.Select(s => s.N))}");
+
+        // Runs straight through by default. Pass "step" to pause between each.
+        var stepwise = args.Contains("step") && selected.Length > 1 && !Console.IsInputRedirected;
+
+        foreach (var s in selected)
+        {
+            if (stepwise)
+            {
+                Console.WriteLine();
+                Ui.Rule('.');
+                Console.WriteLine($"  NEXT  [{s.N} of 9]  {s.Name}");
+                Console.WriteLine($"                     {s.Blurb}");
+                Console.Write("  Enter = run,  s = skip,  q = quit  > ");
+                var key = Console.ReadLine()?.Trim().ToLowerInvariant();
+                if (key == "q") break;
+                if (key == "s") continue;
+            }
+
+            try
+            {
+                await s.Run();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"\n  !! experiment {s.N} ({s.Name}) failed:\n     {ex.Message}\n");
+            }
+        }
+
+        PrintSummary();
+        return 0;
+    }
+
+    private static void PrintMenu(Step[] steps)
+    {
+        Console.WriteLine("\n  AI FOUNDATIONS -- experiments\n");
+        foreach (var s in steps)
+            Console.WriteLine($"    {s.N}  {s.Name,-18}{s.Blurb}");
+        Console.WriteLine("""
+
+              dotnet run            run all nine, straight through
+              dotnet run -- 5       run one
+              dotnet run -- step    pause between each one
+            """);
+    }
+
+    private static void PrintMissingConfig() => Console.WriteLine("""
+
+          Missing configuration.
+
+          Copy appsettings.Development.json.template to
+          appsettings.Development.json and fill in your values:
+
+            {
+              "AzureOpenAI": {
+                "Endpoint":   "https://your-resource.services.ai.azure.com",
+                "Deployment": "gpt-4.1-mini",
+                "ApiKey":     "your-key-here"
+              }
+            }
+
+          That file is gitignored, so the key will not be committed.
+
+          Tip: experiments 8 and 9 need no credentials at all:
+            dotnet run -- 8 9
+        """);
+
+    private static void PrintSummary()
+    {
+        Ui.Banner("WHAT YOU SHOULD BE ABLE TO SAY NOW");
+        Console.WriteLine("""
+
+              THE API SURFACE
+               1. An LLM call is a JSON POST. There is no session, no state.
+               2. Memory is a client-side array that YOU resend on every call.
+               3. finish_reason = "length" is SILENT TRUNCATION with an HTTP 200.
+               4. Tokens are BPE merges, not words. Code and GUIDs cost far more.
+
+              THE PHYSICS UNDERNEATH
+               5. Prefill is parallel and COMPUTE-bound      -> sets TTFT.
+                  Decode is serial and MEMORY-BANDWIDTH-bound -> sets TPOT.
+                  Total latency = TTFT + TPOT x output tokens.
+               6. That is also why output tokens are priced ~4x input tokens.
+               7. At batch 1, decode uses ~0.3% of an H100. Batching is the
+                  escape hatch, and KV cache capacity is what caps the batch.
+               8. Streaming makes nothing faster. It is a UX trick, a good one.
+
+              MEASUREMENT
+               9. On a hosted endpoint, >90% of "model latency" is routing,
+                  queueing and network. Engine prefill was ~30 ms under
+                  ~1300 ms of client-side TTFT. Optimise the right layer.
+              10. Read the WHOLE response. usage.latency_checkpoint and
+                  prompt_tokens_details.cached_tokens answered questions that
+                  were unanswerable with a stopwatch -- and every SDK that maps
+                  responses onto a tidy typed object discards them.
+              11. Know your noise floor before you claim an effect, and be
+                  most suspicious of measurements that flatter you.
+
+              THE ONE GENUINELY NEW THING
+              12. Identical input does not guarantee identical output. Ever.
+                  These systems fail by producing confident, well-formatted,
+                  WRONG output with a 200 OK. Every monitoring instinct you
+                  have assumes failures announce themselves. Here they do not.
+
+              WHERE THIS GOES NEXT
+                  Build a harness that runs one task N times and measures how
+                  often it silently lies. That metric is consistency@k. It is a
+                  distributed-systems problem -- flaky-test triage and
+                  availability math -- handed to ML people, which is exactly
+                  why it is the most valuable gap you can fill.
+
+            """);
+    }
+}

--- a/ai-foundations/README.md
+++ b/ai-foundations/README.md
@@ -1,0 +1,793 @@
+# AI Foundations
+
+A small .NET console project that makes **one call to an AI model completely
+transparent**.
+
+It runs nine experiments. Each one asks a single question, sends real requests,
+prints the real numbers, and explains what they mean. Nothing is simulated and
+nothing is hidden behind a library.
+
+You do not need any AI background to read this. Every term is explained the
+first time it appears.
+
+---
+
+## Why this project exists
+
+Most tutorials show you how to *use* an AI model. You install a library, call
+`.GetResponseAsync()`, and something comes back. That works right up until
+something goes wrong — and then you have no idea why, because a library sits
+between you and the thing you are trying to understand.
+
+This project removes the library.
+
+It talks to the model with a plain `HttpClient` and a JSON POST, which is all
+any AI library ultimately does. Once you have seen the unwrapped version, every
+framework you meet later (Microsoft Agent Framework, Semantic Kernel, LangChain,
+OpenAI SDKs) becomes much easier to reason about, because you know what they are
+wrapping.
+
+**The goal is not to build a product.** The goal is that afterwards you can
+answer the nine questions below from memory.
+
+---
+
+## Vocabulary you need first
+
+Read this once. Everything else assumes these seven terms.
+
+| Term | Plain meaning |
+|---|---|
+| **Token** | A chunk of text the model actually reads. Roughly 3–4 characters of English. Not a word, not a letter. You are billed per token. |
+| **Prompt / input tokens** | Everything you send. |
+| **Completion / output tokens** | Everything the model generates back. |
+| **Prefill** | The model reading your entire prompt. Happens once, all at once. |
+| **Decode** | The model writing the reply, one token at a time. |
+| **TTFT** | *Time To First Token*. How long until the first piece of the answer appears. |
+| **TPOT** | *Time Per Output Token*. How long each following token takes. |
+
+The one sentence that explains most of this project:
+
+> **Reading your prompt (prefill) and writing the reply (decode) are two
+> completely different kinds of work, with two completely different bottlenecks.**
+
+Everything from pricing to latency to why your request is processed alongside
+strangers' requests follows from that.
+
+---
+
+## Running it
+
+You need [.NET 8 or newer](https://dotnet.microsoft.com/download) and access to
+an Azure OpenAI (or compatible) endpoint.
+
+```bash
+cp appsettings.Development.json.template appsettings.Development.json
+```
+
+Then open `appsettings.Development.json` and fill in the three values under the
+`AzureOpenAI` section:
+
+| Setting | What it is | Example |
+|---|---|---|
+| `Endpoint` | Your resource URL | `https://my-resource.services.ai.azure.com/` |
+| `Deployment` | The model deployment name you created | `gpt-4.1-mini` |
+| `ApiKey` | Your API key | `abc123...` |
+
+Pricing lives in `appsettings.json` under `Pricing` (`PerMillionInputUsd` and
+`PerMillionOutputUsd`). Update it to match your model, or experiment 4's dollar
+figures will be wrong.
+
+That file is **gitignored**, so your key is never committed. Do not put a key in
+`appsettings.json` — that one *is* tracked.
+
+```bash
+dotnet run              # run all nine, start to finish
+dotnet run -- 5         # run only experiment 5
+dotnet run -- 1 3 5     # run a subset
+dotnet run -- step      # pause for Enter between each one
+dotnet run -- list      # show the menu
+```
+
+**Experiments 8 and 9 need no API key at all** — they are pure arithmetic:
+
+```bash
+dotnet run -- 8 9
+```
+
+A full run costs **well under one cent** (about $0.002).
+
+### If something goes wrong
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `DeploymentNotFound` | The `Deployment` name does not exist on your resource | List your real deployments: `GET {endpoint}/openai/deployments?api-version=2023-03-15-preview` with an `api-key` header |
+| Config changes seem ignored | `appsettings*.json` is copied to the build output | Run `dotnet build` (not `dotnet run --no-build`) |
+| `endpoint not configured` | Still holds the template placeholder | Edit `appsettings.Development.json`, then rebuild |
+
+---
+
+## The nine experiments
+
+| # | Question it answers | Needs API? |
+|---|---|---|
+| 1 | What actually goes on the wire? | yes |
+| 2 | Why does the model forget everything? | yes |
+| 3 | Why does a GUID cost more than a sentence? | yes |
+| 4 | Where does the money actually go? | yes |
+| 5 | **Why is the first token slow — and how much of that is even the model?** | yes |
+| 6 | What is streaming really? | yes |
+| 7 | **Why can't I write `Assert.Equal` against this?** | yes |
+| 8 | **Why is generating text so inefficient?** | no |
+| 9 | Why is my request processed alongside strangers' requests? | no |
+
+If you only run one, run **5**. The bolded rows are the ones most likely to
+change how you think.
+
+---
+
+## What each experiment found
+
+Below are **real results from real runs**, with the reasoning spelled out. Your
+numbers will differ slightly — that variation is itself one of the lessons.
+
+---
+
+### 1. What actually goes on the wire
+
+**Question:** what is an AI model call, mechanically?
+
+**What we sent** — this is 100% of it:
+
+```json
+{
+  "messages": [
+    { "role": "system", "content": "You are terse. One sentence maximum." },
+    { "role": "user",   "content": "What is the capital of France?" }
+  ],
+  "max_tokens": 50
+}
+```
+
+**What came back:**
+
+```json
+{
+  "message":       { "role": "assistant", "content": "Paris." },
+  "finish_reason": "stop",
+  "usage":         { "prompt_tokens": 26, "completion_tokens": 3, "total_tokens": 29 }
+}
+```
+
+Request size: **156 bytes**. Wall clock: **~800 ms**.
+
+**What this establishes**
+
+There is no session, no connection, no handle, no object living on a server with
+your name on it. You send an array of messages; you get one message back. That
+is the entire integration.
+
+Two fields deserve permanent attention.
+
+**`finish_reason`** tells you *why* generation stopped:
+
+- `"stop"` — the model finished naturally. Good.
+- `"length"` — **you hit your `max_tokens` limit and the answer is cut off.**
+
+We proved the second case by asking for the 20 largest countries with
+`max_tokens: 40`. The reply stopped mid-sentence, at country #1:
+
+```
+Here is a list of the 20 largest countries by total area...
+1. **Russia** – 17,098,242 km²
+2.
+
+finish_reason = "length"   <-- LOOK AT THIS
+```
+
+That response was **HTTP 200**. No exception. No error field. Nothing in any
+monitoring system fires. If you parse it as JSON downstream it breaks; if you
+show it to a user they see a sentence that just stops.
+
+This is your first encounter with the failure mode that runs through this whole
+project: **the system fails by lying quietly, not by erroring.**
+
+**`usage`** is what you are billed for, and the only honest measure of how
+expensive your prompt design really is.
+
+> **A bug we found in our own code here.** This experiment originally printed a
+> tidy C# object instead of the raw response. That looked fine — but it silently
+> discarded fields the server was sending, including two that later turned out
+> to be the most valuable data in the entire project (see experiment 5). Printing
+> the *actual* response body is the only reason we found them.
+
+---
+
+### 2. Why the model forgets everything
+
+**Question:** does the model remember previous messages?
+
+Three calls, seconds apart:
+
+| Call | What we did | Reply |
+|---|---|---|
+| **A** | "Remember the number 8829." | `OK` |
+| **B** | Brand new request: "What number did I tell you?" | *"I don't have a number stored from you."* |
+| **C** | Same question, but we **resent the history ourselves** | `8829` |
+
+**What this establishes**
+
+Call B failed. Call C worked. Same model, same question, same minute. The only
+difference is that in C we put the earlier messages back into the request.
+
+**"Memory" is not a model feature. It is an array on your side that you resend
+on every single call.**
+
+Two consequences worth internalising:
+
+1. **You are writing the model's side of the conversation.** In call C we
+   supplied the assistant's previous reply ourselves. Nothing verified it.
+   Nothing checked the model ever said "OK". You can put words in its mouth —
+   and several legitimate prompting techniques do exactly that.
+
+2. **Long conversations get expensive fast.** A 50-turn conversation resends all
+   50 turns on turn 51. Cost and latency grow with the length of the
+   *conversation*, not the length of your message. Every framework's "memory"
+   feature is managing this array for you.
+
+---
+
+### 3. Why a GUID costs more than a sentence
+
+**Question:** you pay per token — so what is a token, really?
+
+Ten samples, measured:
+
+| Sample | Characters | Tokens | Characters per token |
+|---|---:|---:|---:|
+| plain English | 44 | 17 | 2.59 |
+| C# code | 46 | 22 | 2.09 |
+| a GUID | 36 | 25 | 1.44 |
+| French | 44 | 14 | **3.14** |
+| Hindi | 43 | 21 | 2.05 |
+| Japanese | 15 | 20 | 0.75 |
+| base64 blob | 44 | 28 | 1.57 |
+| indented JSON | 30 | 29 | 1.03 |
+| minified JSON | 19 | 20 | 0.95 |
+| a single `.` | 1 | 8 | **0.12** |
+
+**Spread between best and worst: 25×.** Same API, same price per token, wildly
+different cost per character.
+
+**Why this happens**
+
+The tokenizer was built by **BPE (Byte Pair Encoding)**: an offline process that
+repeatedly merged the most frequent adjacent character pairs in a huge training
+corpus into single tokens. It is **learned compression, not a language rule**.
+Text that looked like the training data compresses well. Text that did not,
+does not.
+
+**Three findings from the table**
+
+1. **Do not trust the folklore.** The widely repeated claim is "non-English costs
+   2–3× more". In our run **French was the cheapest sample of all** — cheaper
+   than English. That old claim was true of an older tokenizer (~100k
+   vocabulary); current ones (~200k) spent much of that extra vocabulary on
+   multilingual merges. Latin-script European languages are now near parity.
+   Japanese and Hindi are still worse per character, but far better than they
+   were. **Measure it for your model rather than assuming.**
+
+2. **Randomness is incompressible, permanently.** GUIDs and base64 sit near 1
+   character per token and always will, because no merge can exist for a
+   sequence that never repeats. If you paste hashes, IDs, or base64 images into
+   prompts, you pay near-worst-case rates. This is not fixable by a better
+   tokenizer.
+
+3. **Formatting whitespace is pure waste.** Identical JSON data cost **29 tokens
+   indented vs 20 minified — a 1.4× tax** for zero benefit, since the model does
+   not care about indentation. Minifying JSON in prompts is one of the very few
+   completely free optimisations available.
+
+**And one surprise:** a single `.` cost **8 tokens**. Every message is wrapped in
+invisible role markers before the model sees it:
+
+```
+<|im_start|>user\n.<|im_end|>\n<|im_start|>assistant\n
+```
+
+You pay that overhead *per message*. Fifty short messages pay it fifty times,
+before a single word of your content.
+
+---
+
+### 4. Where the money goes
+
+**Question:** which costs more — reading or writing?
+
+| Case | In | Out | $ in | $ out | $ total |
+|---|---:|---:|---:|---:|---:|
+| short in, short out | 12 | 2 | 0.000005 | 0.000003 | 0.000008 |
+| short in, **long out** | 18 | 326 | 0.000007 | **0.000522** | 0.000529 |
+| **long in**, short out | 1822 | 9 | 0.000729 | 0.000014 | 0.000743 |
+
+Total for the experiment: **$0.00128**.
+
+**Output tokens cost 4× more than input tokens**, per token. For `gpt-4.1-mini`
+that is $0.40 per million in, $1.60 per million out.
+
+**That ratio is not a pricing decision — it is physics on an invoice:**
+
+- **Input** is processed in **one parallel pass** over the whole prompt
+  (prefill). The GPU does large matrix multiplications. Efficient.
+- **Output** is generated **one token at a time** (decode). Each token requires
+  reading the *entire* model's weights out of GPU memory. Deeply inefficient —
+  experiment 8 measures just how inefficient.
+
+**So both levers matter, differently:**
+
+- Reduce input → better retrieval, cache-aware prompt layout, minified JSON
+- Reduce output → ask for terse or structured replies, set `max_tokens` honestly
+
+**Now extrapolate to an agent.** A 10-step agent loop does **not** cost 10× a
+single call. Each step resends a context that grew by the previous step's
+output. Cost grows roughly **quadratically** with step count. This is why agent
+bills surprise teams who reasoned linearly.
+
+---
+
+### 5. Why the first token is slow — the most important experiment
+
+**Question:** where does the waiting time actually go?
+
+This one has three findings, and the third is the reason to run it.
+
+#### Attempt 1: measure from the client (and fail honestly)
+
+We sent three prompt variants, five times each, and took medians:
+
+| variant | prompt tokens | median TTFT | spread across 5 runs |
+|---|---:|---:|---|
+| short | 21 | 1258 ms | 1048–1408 ms |
+| long, cacheable | 3522 | 1317 ms | 1125–1440 ms |
+| long, random | 3519 | 1305 ms | 842–1580 ms |
+
+A 3,500-token prompt took about the **same** time as a 21-token prompt. The
+theory says longer prompts take longer to read. The measurement disagreed.
+
+**The measurement was not wrong — it was not sensitive enough.**
+
+Look at the spread column: the *short* prompt alone varied by **±360 ms** between
+runs where nothing changed. That is the **noise floor**. Any effect smaller than
+360 ms is invisible here, no matter how real it is.
+
+> **This is the transferable skill.** Know how much your measurement moves when
+> nothing changes, *before* you claim an effect. Most published AI latency
+> comparisons skip this step, which is why they contradict each other.
+
+#### Attempt 2: read the whole response
+
+The server had been telling us the answer the entire time, in a field called
+`usage.latency_checkpoint` — timings measured **inside the service**, with the
+network excluded:
+
+```
+variant            in tok   cached  engine TTFT   pre-inf   client TTFT
+short                  21        0        38 ms    124 ms       1258 ms
+long, cacheable      3522     3456        41 ms    123 ms       1317 ms
+long, random         3510        0       100 ms    128 ms       1305 ms
+```
+
+**Finding A — prefill does scale with prompt length.**
+
+```
+  21 tokens ->  38 ms of engine prefill
+3510 tokens -> 100 ms of engine prefill   (2.6x)
+```
+
+It was never invisible. It was 100 ms hiding under 360 ms of network jitter.
+
+**Finding B — prefix caching, measured exactly.**
+
+Compare rows two and three. Both are ~3,500 tokens, both do the same task. The
+only difference is whether the prompt's opening text is **identical each time**
+or **different each time**.
+
+```
+long, cacheable : 3456 of 3522 prompt tokens served from cache   (98%)
+long, random    :    0 of 3510 prompt tokens served from cache   (0%)
+
+long, cacheable :  41 ms of prefill
+long, random    : 100 ms of prefill      (2.4x the work)
+```
+
+**Prefix caching** means the provider recognises that it has already processed
+the beginning of your prompt and reuses that work instead of redoing it. Cached
+tokens are also **billed at a quarter of the normal rate** — $0.10 per million
+instead of $0.40.
+
+The practical rule follows directly:
+
+> **Put stable content FIRST** (system prompt, policy text, examples).
+> **Put volatile content LAST** (user input, timestamps, IDs).
+
+One volatile token near the front invalidates the cache for everything after it.
+A timestamp or request ID at the top of a prompt quietly turns a 98% hit rate
+into 0%. Nothing errors. Nobody notices until someone reads the bill.
+
+**Finding C — most of your latency is not the model.**
+
+Read the last two columns together:
+
+```
+engine prefill : ~40 ms      <- the model actually working
+client TTFT    : ~1300 ms    <- what you experience
+```
+
+**Over 90% of what you would call "model latency" is routing, queueing, TLS and
+network.** If you were asked to make this endpoint feel faster, the model is the
+wrong place to look — and that conclusion is invisible from the client and
+obvious from one field in the response body.
+
+#### And the timing we got wrong
+
+We also tried to measure **TPOT** (time per output token) by timestamping each
+piece of the streamed response. It reported **0.23 ms per token**.
+
+That is impossible. Every token requires a full pass through the model —
+milliseconds, not microseconds. What actually happened is that the provider
+generated many tokens and sent them in a single network write, so we were timing
+our own socket reads, not the model.
+
+The server's own clock gives the real figure:
+
+```
+your client measured   0.23 ms per token
+the engine reports     6.00 ms per token   <-- the real one
+```
+
+**About 26× wrong — in the direction that made things look faster.**
+
+Note that nothing errored. The number was well-formatted, plausible, and
+completely meaningless. Measurement bugs are rarely neutral; they tend to favour
+whatever you were hoping to see, which is exactly why you should check hardest
+when the result is good news.
+
+---
+
+### 6. What streaming actually is
+
+**Question:** when text appears word by word, what is really happening?
+
+The raw chunks, in arrival order:
+
+```
+"Hello" | " there" | "," | " my" | " friend" | "."
+```
+
+Those ragged pieces are not a network artifact — **those are the tokens**. Note
+that `" there"` includes its leading space, and `","` arrives alone. That is what
+the tokenizer produced.
+
+Streaming uses **Server-Sent Events (SSE)**: an ordinary HTTP response held open,
+emitting `data:` lines until it finally sends `data: [DONE]`.
+
+**But look at the arrival timeline:**
+
+```
+    454  (+   454)  ############################ "Hello"
+    454  (+     0)   " there"
+    454  (+     0)   ","
+    455  (+     0)   " my"
+    455  (+     0)   " friend"
+    455  (+     0)   "."
+```
+
+All six arrived in the same millisecond. So we tested a longer generation:
+
+```
+chunks              : 239
+distinct flushes    : 6        (gaps >= 0.5 ms)
+chunks per flush    : 39.8
+median non-zero gap : 18.2 ms
+```
+
+239 tokens arrived in **6 network writes**, about 40 tokens each. You are
+measuring the provider's **flush policy**, not the model's generation speed.
+
+So this experiment shows you the correct **token boundaries** — which is its
+point — but not true generation timing. For that, experiment 5 reads the
+engine's own clock and experiment 8 derives an independent figure from hardware.
+
+**Two things the API quietly does for you here:**
+
+1. **Detokenization.** Token IDs → bytes → text, buffered until a complete UTF-8
+   character exists. That buffering is why chunk boundaries look arbitrary, and
+   why an emoji may arrive as one chunk after a pause.
+2. **Hiding token IDs entirely.** The model never saw your string — it saw an
+   array of integers. The tokenizer runs **server-side**. That is why you send
+   text rather than IDs, and why you cannot know your exact token count before
+   sending.
+
+**Streaming makes nothing faster.** It changes which number the user perceives —
+from total time to time-to-first-token. It is a UX technique, and a good one.
+
+---
+
+### 7. Same input, different output
+
+**Question:** can I test this like normal code?
+
+Five identical requests, twice over.
+
+**`temperature: 1.0`** (the default — sample from the probability distribution):
+
+```
+Brew & Bloom  |  Brew Haven  |  Brew & Bloom Café  |  Brew & Bloom Café  |  Brew & Bliss Café
+distinct: 4 / 5
+```
+
+**`temperature: 0.0`** (greedy — always take the single most likely token):
+
+```
+Brew & Bloom Café  |  Brew & Bloom Café  |  Brew & Bloom  |  Brew & Bloom Café  |  Brew & Bloom Café
+distinct: 2 / 5
+```
+
+**Read that second result again.** Temperature 0 is supposed to be deterministic.
+Identical bytes on the wire, greedy decoding, and it *still* disagreed with
+itself.
+
+**Why:** your request is processed in a batch alongside other people's requests
+(experiment 9 explains why). GPU floating-point addition is not associative —
+`(a + b) + c` can differ from `a + (b + c)` in the last decimal place. Different
+batch neighbours mean a different summation order, a slightly different number,
+and occasionally a different "most likely" token. Once one token differs, the
+rest of the sentence can diverge completely.
+
+**You cannot write `Assert.Equal` against this.** Not "should not" — *cannot*.
+
+That single fact is why evaluating AI systems is a **discipline** rather than a
+test suite. The right question is never:
+
+> ~~"Is the output correct?"~~
+
+It is:
+
+> **"Over N runs, what fraction were correct — and what do the failures have in
+> common?"**
+
+That metric has a name: **`consistency@k`**. Building a harness for it is the
+natural next project after this one.
+
+---
+
+### 8. Why generating text is so inefficient (no API key needed)
+
+**Question:** why is decode so much slower than prefill?
+
+This experiment is pure arithmetic. It needs no credentials and no network.
+
+**The key concept: arithmetic intensity (AI)**
+
+```
+arithmetic intensity = FLOPs performed / bytes moved from memory
+```
+
+It answers: *for every byte I drag out of memory, how much math do I do with it?*
+Every GPU has a **ridge point** — the intensity at which it stops starving for
+data and starts being limited by math.
+
+| GPU | Memory bandwidth | Peak compute | Ridge point |
+|---|---:|---:|---:|
+| H100 | 3350 GB/s | 989 TFLOP/s | **295 FLOP/byte** |
+| A100 | 2039 GB/s | 312 TFLOP/s | 153 FLOP/byte |
+
+Now the two phases, for a 70-billion-parameter model at 2 bytes per parameter
+(**140 GB of weights**):
+
+**Decode — generating ONE token:**
+```
+bytes moved : 140 GB    (the entire model, for every single token)
+FLOPs       : 140 GFLOP
+AI          = 1.0 FLOP/byte
+```
+
+An H100 needs **295** to be busy. Decode delivers **1.0**.
+
+> **You are using roughly 0.34% of the GPU's compute capability.** It is almost
+> entirely idle, waiting on memory.
+
+**Prefill — reading 1000 prompt tokens:**
+```
+bytes moved : 140 GB    (the same weights, ONCE, for all 1000 tokens)
+FLOPs       : 140 TFLOP
+AI          = 1000 FLOP/byte
+```
+
+Well past the ridge point. **Prefill is compute-bound. Decode is memory-bound.**
+Same model, same GPU, same request — opposite bottlenecks, milliseconds apart.
+
+**A prediction from physics alone**
+
+If decode really is bandwidth-bound, token rate should be almost exactly:
+
+```
+memory bandwidth / model size = 3350 GB/s / 140 GB = 23.9 tokens/sec
+```
+
+Published figures for 70B models on a single H100 land in the 20–30 tok/s range.
+That prediction used no benchmark, no profiler, and no knowledge of the
+architecture beyond parameter count.
+
+**Now run it backwards**
+
+Experiment 5 recovered a real figure from the server: **6.0 ms per token**. Turn
+the equation around:
+
+```
+bytes per token = 6.0 ms x 3350 GB/s = 20 GB of weights
+  at 2 bytes/parameter -> ~10 billion parameters
+  at 1 byte/parameter  -> ~20 billion parameters
+```
+
+Treat that as an order of magnitude, not a measurement — it assumes H100-class
+hardware, ignores other memory traffic, and your request was batched, which
+pushes the estimate upward. But sit with what happened: **from one timing field,
+with no architecture details and no insider information, you bounded the size of
+a proprietary model to within an order of magnitude.**
+
+That is what it means for a bottleneck to be *real*. When a system is pinned
+against physics, the physics tells you about the system.
+
+**Why the 0.3% number explains the industry**
+
+- **Why memory sold out before GPUs did.** If decode is bandwidth-bound, the
+  scarce resource is bandwidth, not compute. The H200 is an H100 with more and
+  faster memory and *identical* compute. That product exists because of this
+  ratio.
+- **Why quantisation is so effective.** Halving bytes per parameter nearly halves
+  decode latency, because you move half as much memory. It buys speed directly,
+  not just space.
+- **Why Mixture-of-Experts models exist.** They activate only a fraction of
+  parameters per token, so fewer bytes move. A bandwidth optimisation wearing an
+  architecture costume.
+
+---
+
+### 9. Why you share a GPU with strangers (no API key needed)
+
+**Question:** if one request wastes 99.7% of a GPU, how is this affordable?
+
+**The key insight: one load of the weights can serve many requests.**
+
+The weights move from memory to the compute units once per step regardless of
+how many sequences are in the batch. Bytes stay constant while the math
+multiplies. Arithmetic intensity rises linearly with batch size — for free.
+
+| Batch | AI (FLOP/byte) | % of ridge point | tokens/sec total | tokens/sec each |
+|---:|---:|---:|---:|---:|
+| 1 | 1 | 0.3% | 24 | 23.9 |
+| 4 | 4 | 1.4% | 96 | 23.9 |
+| 16 | 16 | 5.4% | 383 | 23.9 |
+| 64 | 64 | 21.7% | 1531 | 23.9 |
+| 128 | 128 | 43.4% | 3063 | 23.9 |
+| 256 | 256 | 86.7% | 6126 | 23.9 |
+
+Read the last two columns carefully:
+
+- **tokens/sec total** rises roughly linearly with batch size → *throughput*
+- **tokens/sec each** stays flat → *your latency is unchanged*
+
+Batching is nearly **free throughput**, until intensity crosses the ridge point
+at 295, after which you are genuinely compute-bound and further batching starts
+costing per-request latency.
+
+**What this explains**
+
+- **Why your request is batched with strangers'.** At batch 1 a provider wastes
+  99.7% of the GPU. At batch 128 they are near the ridge. Serving you alone would
+  cost roughly 100× more. This is also the direct cause of experiment 7 — your
+  batch neighbours change the floating-point summation order.
+- **Why "continuous batching" was a breakthrough.** Naive batching waits for
+  every sequence to finish, so one long generation stalls 127 short ones.
+  Continuous batching evicts finished sequences and admits new ones every step,
+  keeping the batch full. It is work-stealing for token generation, and it
+  roughly 2–4×'d industry throughput.
+- **Why KV cache memory is the real limit.** If batching is free throughput, why
+  not batch 10,000? Because each sequence needs its own **KV cache** (the stored
+  intermediate state for tokens already processed), and that lives in the same
+  memory as the weights. Maximum batch size — and therefore a provider's entire
+  cost structure — is set by how much KV cache fits.
+- **Why PagedAttention mattered.** By removing memory fragmentation it took KV
+  cache utilisation from ~20–40% to over 90% → bigger batches → lower cost per
+  token. A memory-management technique from 1960s operating systems is
+  responsible for a large share of the price drop in AI inference.
+
+---
+
+## Mistakes we made building this, and what they teach
+
+These are worth more than the results, because they are the kind of error that
+produces a *confident wrong answer* rather than a crash.
+
+**1. A control group contaminated by the effect it was controlling for.**
+
+Experiment 5 needed an "uncacheable" prompt. It generated random text using
+`new Random(12345)` — a **fixed seed**. That produces the *same* "random" text on
+every run, so the provider cached it happily and the control reported **98%
+cached**. The experiment was measuring the very thing it was supposed to rule
+out. Fixed by using `Guid.NewGuid()`, which is unique across runs.
+
+*Lesson: "random" is not the same as "unique". Check your control group produces
+the value you expect — here, exactly zero cache hits.*
+
+**2. A helper function that was right for one use and wrong for another.**
+
+A `Median()` helper skipped zero values — correct for latencies, where zero means
+"field missing". Then it was reused for **cached token counts**, where zero is
+the single most meaningful value there is. Cache misses vanished from the
+average, making caching look universal.
+
+*Lesson: when you reuse a helper, re-check its assumptions in the new context.*
+
+**3. Printing a tidy object instead of the raw response.**
+
+Experiment 1 originally serialised a C# record. It looked correct. It silently
+dropped `usage.latency_checkpoint` and `prompt_tokens_details.cached_tokens` —
+the two fields that made experiment 5's real findings possible.
+
+*Lesson: before building a harness to measure something through a noisy channel,
+read the entire raw response. Providers ship far more telemetry than their SDKs
+expose, and every library that maps responses onto a neat typed object throws
+some of it away.*
+
+---
+
+## Files
+
+| File | What it contains |
+|---|---|
+| `RawModelClient.cs` | The entire integration — one HTTP POST, plus SSE parsing that timestamps every chunk |
+| `Experiments.cs` | Experiments 1–7 (real API calls) |
+| `HardwareMath.cs` | Experiments 8–9 (arithmetic only, no network) |
+| `Program.cs` | Configuration loading and the experiment runner |
+| `Ui.cs` | Console formatting |
+| `appsettings.json` | Endpoint, deployment and pricing. **Tracked — no secrets** |
+| `appsettings.Development.json` | Your API key. **Gitignored** |
+
+The project deliberately depends on only three configuration packages. **No AI
+SDK, no agent framework, no Azure client library** — that is the point.
+
+---
+
+## Checklist: you are done when you can explain, without notes
+
+- [ ] Why an AI call has no session or server-side state
+- [ ] Why "memory" is your array, and what a 50-turn conversation really sends
+- [ ] Why `finish_reason: "length"` is dangerous despite HTTP 200
+- [ ] Why a GUID costs more than a sentence of the same length
+- [ ] Why generating 1,000 tokens costs ~4× reading 1,000 tokens
+- [ ] The difference between prefill and decode, and which bottleneck each hits
+- [ ] What fraction of your endpoint's latency is actually inference
+- [ ] Why putting stable content first can cut input cost by 4×
+- [ ] Why you must state your noise floor before claiming a latency result
+- [ ] Why `temperature: 0` still is not reproducible
+- [ ] Why decode uses ~0.3% of a GPU, and why batching is the escape hatch
+- [ ] How to estimate a hosted model's size from its per-token latency
+- [ ] The one failure mode that no standard monitoring catches
+
+---
+
+## What comes next
+
+Experiment 7 sets up the real problem: identical input, different output. You
+cannot write `Assert.Equal` against it, so correctness has to become a **measured
+rate** rather than a true/false answer.
+
+The answer is a harness that runs one task N times and reports how often it
+quietly gets it wrong — **`consistency@k`**. Everything needed to build it
+already exists in this project: the raw client, cost accounting, and the
+repeat-and-take-medians plumbing from experiment 5.
+
+It is essentially flaky-test triage and availability math, applied to a component
+that fails by producing confident, well-formatted, wrong output with a 200 OK.

--- a/ai-foundations/RawModelClient.cs
+++ b/ai-foundations/RawModelClient.cs
@@ -1,0 +1,245 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+
+namespace Lab01;
+
+/// <summary>
+/// A deliberately tiny, hand-rolled client for the chat completions endpoint.
+///
+/// This is the whole "AI integration". Every SDK, every agent framework, every
+/// orchestration library in existence is a wrapper around this one HTTP POST.
+/// Seeing it at this level once is worth more than a month of tutorials.
+/// </summary>
+internal sealed class RawModelClient
+{
+    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromMinutes(5) };
+
+    private readonly string _url;
+    private readonly string _apiKey;
+
+    public RawModelClient(string endpoint, string deployment, string apiVersion, string apiKey)
+    {
+        _url = $"{endpoint.TrimEnd('/')}/openai/deployments/{deployment}" +
+               $"/chat/completions?api-version={apiVersion}";
+        _apiKey = apiKey;
+    }
+
+    private void ApplyAuth(HttpRequestMessage req) => req.Headers.Add("api-key", _apiKey);
+
+    /// <summary>Builds the request body. This object IS your entire conversation.</summary>
+    public static Dictionary<string, object?> BuildBody(
+        IEnumerable<Msg> messages,
+        int? maxTokens = null,
+        double? temperature = null,
+        bool stream = false,
+        bool includeUsageInStream = true)
+    {
+        var body = new Dictionary<string, object?>
+        {
+            ["messages"] = messages.Select(m => new { role = m.Role, content = m.Content }).ToArray(),
+        };
+
+        if (maxTokens is not null) body["max_tokens"] = maxTokens;
+        if (temperature is not null) body["temperature"] = temperature;
+
+        if (stream)
+        {
+            body["stream"] = true;
+            // Streaming responses omit `usage` unless you ask for it. If you bill
+            // or budget on tokens, forgetting this silently loses your telemetry.
+            if (includeUsageInStream)
+                body["stream_options"] = new { include_usage = true };
+        }
+
+        return body;
+    }
+
+    /// <summary>One blocking POST. Returns the parsed response and wall-clock time.</summary>
+    public async Task<(JsonDocument Json, TimeSpan Elapsed, int RequestBytes)> SendAsync(
+        Dictionary<string, object?> body, CancellationToken ct = default)
+    {
+        var payload = JsonSerializer.Serialize(body);
+        using var req = new HttpRequestMessage(HttpMethod.Post, _url)
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+        };
+        ApplyAuth(req);
+
+        var sw = Stopwatch.StartNew();
+        using var resp = await Http.SendAsync(req, ct);
+        var raw = await resp.Content.ReadAsStringAsync(ct);
+        sw.Stop();
+
+        if (!resp.IsSuccessStatusCode)
+            throw new HttpRequestException($"HTTP {(int)resp.StatusCode}\n{Trim(raw, 1500)}");
+
+        return (JsonDocument.Parse(raw), sw.Elapsed, Encoding.UTF8.GetByteCount(payload));
+    }
+
+    /// <summary>
+    /// Streaming POST. Reads Server-Sent Events line by line and records the
+    /// arrival time of every chunk, which is what lets us separate TTFT from TPOT.
+    /// </summary>
+    public async Task<StreamResult> StreamAsync(
+        Dictionary<string, object?> body, CancellationToken ct = default)
+    {
+        var payload = JsonSerializer.Serialize(body);
+        using var req = new HttpRequestMessage(HttpMethod.Post, _url)
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+        };
+        ApplyAuth(req);
+
+        var sw = Stopwatch.StartNew();
+        using var resp = await Http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+        var raw0 = resp.IsSuccessStatusCode ? null : await resp.Content.ReadAsStringAsync(ct);
+        if (raw0 is not null)
+            throw new HttpRequestException($"HTTP {(int)resp.StatusCode}\n{Trim(raw0, 1500)}");
+
+        await using var stream = await resp.Content.ReadAsStreamAsync(ct);
+        using var reader = new StreamReader(stream);
+
+        var text = new StringBuilder();
+        var chunks = new List<string>();
+        var arrivals = new List<double>();
+        TimeSpan? ttft = null;
+        Usage? usage = null;
+        string? finishReason = null;
+
+        while (await reader.ReadLineAsync(ct) is { } line)
+        {
+            if (!line.StartsWith("data:", StringComparison.Ordinal)) continue;
+
+            var data = line[5..].Trim();
+            if (data == "[DONE]") break;
+
+            using var doc = JsonDocument.Parse(data);
+            var root = doc.RootElement;
+
+            if (root.TryGetProperty("usage", out var u) && u.ValueKind == JsonValueKind.Object)
+                usage = Usage.From(u);
+
+            if (!root.TryGetProperty("choices", out var choices) || choices.GetArrayLength() == 0)
+                continue;
+
+            var choice = choices[0];
+            if (choice.TryGetProperty("finish_reason", out var fr) && fr.ValueKind == JsonValueKind.String)
+                finishReason = fr.GetString();
+
+            if (!choice.TryGetProperty("delta", out var delta)) continue;
+            if (!delta.TryGetProperty("content", out var c) || c.ValueKind != JsonValueKind.String) continue;
+
+            var piece = c.GetString();
+            if (string.IsNullOrEmpty(piece)) continue;
+
+            ttft ??= sw.Elapsed;
+            arrivals.Add(sw.Elapsed.TotalMilliseconds);
+            chunks.Add(piece);
+            text.Append(piece);
+        }
+
+        sw.Stop();
+
+        return new StreamResult(
+            text.ToString(), chunks, arrivals, ttft ?? TimeSpan.Zero,
+            sw.Elapsed, usage, finishReason, Encoding.UTF8.GetByteCount(payload));
+    }
+
+    private static string Trim(string s, int n) => s.Length <= n ? s : s[..n] + "...";
+}
+
+internal readonly record struct Msg(string Role, string Content)
+{
+    public static Msg System(string c) => new("system", c);
+    public static Msg User(string c) => new("user", c);
+    public static Msg Assistant(string c) => new("assistant", c);
+}
+
+internal sealed record Usage(int PromptTokens, int CompletionTokens, int TotalTokens)
+{
+    /// <summary>
+    /// Tokens the provider served from its prefix cache rather than re-running
+    /// prefill on. This is GROUND TRUTH for prefix caching -- unlike wall-clock
+    /// timing from a laptop, it cannot be confounded by network noise.
+    /// Billed at a fraction of the normal input rate.
+    /// </summary>
+    public int CachedTokens { get; init; }
+
+    /// <summary>
+    /// Server-side timing breakdown, when the provider supplies it (Azure does,
+    /// under usage.latency_checkpoint). These are measured INSIDE the service,
+    /// so they exclude your network path entirely.
+    ///   EngineTtftMs -- real prefill time on the GPU.
+    ///   EngineTbtMs  -- real time-between-tokens, i.e. honest TPOT.
+    ///   PreInferenceMs -- routing/queueing before the model ever ran.
+    /// </summary>
+    public double EngineTtftMs { get; init; }
+    public double EngineTbtMs { get; init; }
+    public double PreInferenceMs { get; init; }
+    public bool HasServerTiming => EngineTtftMs > 0 || EngineTbtMs > 0;
+
+    public static Usage From(JsonElement u)
+    {
+        var usage = new Usage(
+            u.TryGetProperty("prompt_tokens", out var p) ? p.GetInt32() : 0,
+            u.TryGetProperty("completion_tokens", out var c) ? c.GetInt32() : 0,
+            u.TryGetProperty("total_tokens", out var t) ? t.GetInt32() : 0);
+
+        if (u.TryGetProperty("prompt_tokens_details", out var d) &&
+            d.TryGetProperty("cached_tokens", out var ct))
+            usage = usage with { CachedTokens = ct.GetInt32() };
+
+        if (u.TryGetProperty("latency_checkpoint", out var l))
+            usage = usage with
+            {
+                EngineTtftMs = Num(l, "engine_ttft_ms"),
+                EngineTbtMs = Num(l, "engine_tbt_ms"),
+                PreInferenceMs = Num(l, "pre_inference_ms"),
+            };
+
+        return usage;
+
+        static double Num(JsonElement e, string name) =>
+            e.TryGetProperty(name, out var v) && v.TryGetDouble(out var d) ? d : 0;
+    }
+}
+
+internal sealed record StreamResult(
+    string Text,
+    List<string> Chunks,
+    List<double> ArrivalsMs,
+    TimeSpan Ttft,
+    TimeSpan Total,
+    Usage? Usage,
+    string? FinishReason,
+    int RequestBytes)
+{
+    /// <summary>
+    /// Mean gap between chunk arrivals -- our measured Time Per Output Token.
+    /// Measured from the FIRST chunk onward, so prefill time is excluded.
+    /// </summary>
+    public double TpotMs => ArrivalsMs.Count < 2
+        ? 0
+        : (ArrivalsMs[^1] - ArrivalsMs[0]) / (ArrivalsMs.Count - 1);
+
+    /// <summary>
+    /// True when the provider coalesced many tokens into one network flush.
+    ///
+    /// Real decode requires a full forward pass per token -- single-digit to
+    /// tens of milliseconds. If most inter-chunk gaps are sub-millisecond, we
+    /// are timing our own socket reads, not the GPU, and TPOT is meaningless.
+    /// Detecting this matters: the numbers look perfectly plausible either way.
+    /// </summary>
+    public bool LooksBuffered
+    {
+        get
+        {
+            if (ArrivalsMs.Count < 4) return false;
+            var nearZero = 0;
+            for (var i = 1; i < ArrivalsMs.Count; i++)
+                if (ArrivalsMs[i] - ArrivalsMs[i - 1] < 0.5) nearZero++;
+            return nearZero > (ArrivalsMs.Count - 1) * 0.6;
+        }
+    }
+}

--- a/ai-foundations/Ui.cs
+++ b/ai-foundations/Ui.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+
+namespace Lab01;
+
+/// <summary>Console formatting only. Nothing interesting here.</summary>
+internal static class Ui
+{
+    private const int Width = 76;
+
+    private static readonly JsonSerializerOptions Pretty = new() { WriteIndented = true };
+
+    public static void Rule(char c = '-') => Console.WriteLine("  " + new string(c, Width));
+
+    public static void Header(int n, string title)
+    {
+        Console.WriteLine();
+        Rule('=');
+        Console.WriteLine($"  EXPERIMENT {n}: {title}");
+        Rule('=');
+    }
+
+    public static void Banner(string line1, params string[] rest)
+    {
+        Console.WriteLine();
+        Rule('#');
+        Console.WriteLine("  " + line1);
+        foreach (var r in rest) Console.WriteLine("  " + r);
+        Rule('#');
+    }
+
+    /// <summary>The commentary blocks. This is the actual content of the lab.</summary>
+    public static void Note(string text)
+    {
+        Console.WriteLine();
+        foreach (var line in text.Replace("\r", "").Split('\n'))
+            Console.WriteLine("  | " + line);
+        Console.WriteLine();
+    }
+
+    public static void Json(object o) =>
+        Console.WriteLine("    " + JsonSerializer.Serialize(o, Pretty).Replace("\n", "\n    "));
+}

--- a/ai-foundations/appsettings.Development.json.template
+++ b/ai-foundations/appsettings.Development.json.template
@@ -1,0 +1,8 @@
+{
+  "AzureOpenAI": {
+    "Endpoint": "https://your-resource.openai.azure.com",
+    "Deployment": "gpt-4o-mini",
+    "ApiVersion": "2024-10-21",
+    "ApiKey": "PASTE-YOUR-KEY-HERE"
+  }
+}

--- a/ai-foundations/appsettings.json
+++ b/ai-foundations/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "AzureOpenAI": {
+    "Endpoint": "https://your-resource.services.ai.azure.com",
+    "Deployment": "gpt-4.1-mini",
+    "ApiVersion": "2024-10-21",
+    "ApiKey": ""
+  },
+  "Pricing": {
+    "PerMillionInputUsd": 0.4,
+    "PerMillionOutputUsd": 1.6
+  }
+}


### PR DESCRIPTION
A self-contained .NET 8 console project that makes a single LLM call completely transparent. Raw HttpClient against the chat completions endpoint -- no SDK, no agent framework, no Azure client library -- so nothing sits between the reader and the thing being explained.

Nine experiments, each isolating one fact:

  1-4  the wire, statelessness, tokenization, cost
  5    latency: client-side TTFT, then the engine's own clock
  6    streaming: token boundaries vs provider flush policy
  7    non-determinism, including at temperature 0
  8-9  roofline and batching (pure arithmetic, no API key needed)

Experiment 5 reads usage.latency_checkpoint and
prompt_tokens_details.cached_tokens from the raw response. These fields resolve what client-side timing cannot: prefill scaling (38ms -> 100ms), prefix caching (3456/3522 tokens cached vs 0/3510), and the fact that
>90% of observed "model latency" is routing and network rather than
inference. Experiment 8 inverts the roofline against the engine's real 6ms/token to bound the served model at ~10B parameters.

Three measurement bugs found and fixed during development, documented in the README because they produced confident wrong answers rather than errors:

  * the "uncacheable" control used new Random(fixed seed), so it generated identical text every run and was served from cache -- the control was contaminated by the effect it controlled for
  * a Median() helper skipped zeros, correct for latencies but wrong for cached-token counts where zero is the meaningful value
  * experiment 1 serialised a C# record instead of the raw response, silently discarding the two fields above

Credentials live in appsettings.Development.json, which is gitignored. The tracked appsettings.json holds placeholders only.