### PR TITLE
Add context-engineering demos

### DIFF
--- a/llm-context-engineering/budget.py
+++ b/llm-context-engineering/budget.py
@@ -1,0 +1,130 @@
+"""
+budget.py -- Token budgeting as a fixed-size allocator.
+
+Module 02 - Context Engineering, Lesson 2.
+
+The context window is a fixed pool of tokens shared by everything the model
+needs: system prompt, tool defs, retrieved docs, conversation history, the
+user's new message -- AND the space reserved for the reply.
+
+This is an admission-control / allocator problem:
+  1. Reserve output space first (input and output share the window).
+  2. Place mandatory items (system, tools, new message). If they don't fit,
+     that's a hard error.
+  3. Fill remaining "flex" budget with history, newest-first.
+  4. Evict whatever doesn't fit, lowest priority first.
+
+Pure Python. No dependencies. Run:  python3 budget.py
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Item:
+    name: str
+    tokens: int
+    priority: str  # "mandatory" or "flex"
+
+
+def pack(window: int, reserved_output: int, mandatory: list, history: list):
+    """
+    window          : total context window in tokens
+    reserved_output : tokens held back for the reply (never used by input)
+    mandatory       : items that must be present (system, tools, new message)
+    history         : conversation turns, OLDEST-FIRST (we keep newest)
+
+    Returns (included, evicted, report_lines).
+    """
+    input_budget = window - reserved_output
+    report = []
+    report.append(f"window            = {window:>6} tokens")
+    report.append(f"reserved (output) = {reserved_output:>6} tokens  (protected -- input may never use this)")
+    report.append(f"input budget      = {input_budget:>6} tokens  (window - reserved)")
+    report.append("")
+
+    # --- Step 1: mandatory items come out of the budget first ---
+    mandatory_total = sum(i.tokens for i in mandatory)
+    report.append("MANDATORY (always included; error if these alone overflow):")
+    for i in mandatory:
+        report.append(f"   [keep] {i.name:<22} {i.tokens:>6}")
+    report.append(f"   mandatory total       {mandatory_total:>6}")
+    report.append("")
+
+    if mandatory_total > input_budget:
+        report.append(f"!! HARD ERROR: mandatory {mandatory_total} > input budget {input_budget}.")
+        report.append("   Nothing to evict -- you must shrink the system prompt / message itself.")
+        return [], history[:], report
+
+    flex_budget = input_budget - mandatory_total
+    report.append(f"flex budget       = {flex_budget:>6} tokens  (input budget - mandatory)")
+    report.append("")
+
+    # --- Step 2: fill flex budget with history, NEWEST first ---
+    report.append("HISTORY (newest-first; keep until the next turn won't fit):")
+    included = []
+    evicted = []
+    remaining = flex_budget
+    for turn in reversed(history):  # newest first
+        if turn.tokens <= remaining:
+            included.append(turn)
+            remaining -= turn.tokens
+            report.append(f"   [keep] {turn.name:<22} {turn.tokens:>6}   (remaining flex: {remaining})")
+        else:
+            evicted.append(turn)
+            report.append(f"   [DROP] {turn.name:<22} {turn.tokens:>6}   (won't fit in {remaining})")
+
+    included_tokens = mandatory_total + sum(t.tokens for t in included)
+    report.append("")
+    report.append(f"USED  = {included_tokens} / {input_budget} input tokens "
+                  f"({included_tokens * 100 // input_budget}% of input budget)")
+    report.append(f"TOTAL = {included_tokens + reserved_output} / {window} window "
+                  f"(incl. {reserved_output} reserved for reply)")
+    report.append(f"EVICTED {len(evicted)} old turn(s): {[t.name for t in evicted] or 'none'}")
+
+    return [m for m in mandatory] + list(reversed(included)), evicted, report
+
+
+def scenario(title, window, reserved_output, mandatory, history):
+    print("=" * 70)
+    print(f"  {title}")
+    print("=" * 70)
+    _, _, report = pack(window, reserved_output, mandatory, history)
+    print("\n".join(report))
+    print()
+
+
+if __name__ == "__main__":
+    # A small 8K window so the effects are easy to see.
+    mandatory = [
+        Item("system_prompt", 800, "mandatory"),
+        Item("tool_defs", 600, "mandatory"),
+        Item("user_new_message", 300, "mandatory"),
+    ]
+    # Conversation history, oldest-first. 10 turns of ~500 tokens each.
+    history = [Item(f"turn_{i:02d}", 500, "flex") for i in range(1, 11)]
+
+    # Scenario A: generous window -- everything fits.
+    scenario("A. 8K window, 1K reserved for reply -- most history fits",
+             window=8000, reserved_output=1000,
+             mandatory=mandatory, history=history)
+
+    # Scenario B: same content, but we reserve MORE for the reply.
+    # Less input budget -> more old turns get evicted.
+    scenario("B. Same, but reserve 3K for a long reply -- more eviction",
+             window=8000, reserved_output=3000,
+             mandatory=mandatory, history=history)
+
+    # Scenario C: a big retrieved document shows up as mandatory-ish content.
+    # Watch it crowd out history.
+    mandatory_with_doc = mandatory + [Item("retrieved_doc", 3500, "mandatory")]
+    scenario("C. A 3.5K retrieved doc lands -- it crowds out most history",
+             window=8000, reserved_output=1000,
+             mandatory=mandatory_with_doc, history=history)
+
+    # Scenario D: mandatory items alone blow the budget -> hard error.
+    huge_system = [Item("HUGE_system_prompt", 7500, "mandatory"),
+                   Item("user_new_message", 300, "mandatory")]
+    scenario("D. Oversized system prompt -- mandatory alone overflows (hard error)",
+             window=8000, reserved_output=1000,
+             mandatory=huge_system, history=history)

--- a/llm-context-engineering/compress.py
+++ b/llm-context-engineering/compress.py
@@ -1,0 +1,148 @@
+"""
+compress.py -- What comes off the desk when history overflows, and how.
+
+Module 02 - Context Engineering, Lesson 4.
+
+History grows every turn; the budget is fixed. Eventually you must remove
+something. Four policies, from dumbest to smartest:
+
+  (a) drop-oldest  : FIFO. keep last N turns. hard forgetting.
+  (b) summarize    : replace old turns with a short LLM-made summary. lossy but graceful.
+  (c) retrieve     : store all old turns externally; fetch only relevant ones on demand.
+  (d) hybrid/pin   : pin must-keeps + keep recent verbatim + summarize middle + retrieve details.
+
+Engineering framing: a memory hierarchy.
+  hot   = last few turns verbatim   (L1)
+  warm  = rolling summary of middle (RAM)
+  cold  = vector store of old turns (disk, retrieve on miss)
+
+This sim can't call a real LLM (offline, pure Python), so "summarize" and
+"embedding retrieval" are faked with simple heuristics -- the POINT is the
+policy behavior and what information survives, not model quality.
+
+Run:  python3 compress.py
+"""
+
+TOKENS_PER_TURN = 500
+BUDGET = 3000          # tokens available for history (after mandatory + reserved)
+
+# A fake 20-turn conversation. Turn 2 plants a critical fact the user will
+# refer back to at turn 20.
+def build_conversation():
+    turns = []
+    for i in range(1, 21):
+        if i == 2:
+            text = "user: please remember my account ID is ACC-7788"
+        elif i == 20:
+            text = "user: what was my account ID again?"
+        else:
+            text = f"user: message number {i} about various topics"
+        turns.append({"idx": i, "text": text, "tokens": TOKENS_PER_TURN})
+    return turns
+
+
+def fits(tokens):
+    return "FITS " if tokens <= BUDGET else "OVER!"
+
+
+def contains_fact(kept_texts):
+    return any("ACC-7788" in t for t in kept_texts)
+
+
+def report(name, kept_texts, extra_cost_note=""):
+    tokens = len(kept_texts) * TOKENS_PER_TURN if kept_texts else 0
+    # summaries count differently; caller may override by passing token estimate
+    return name, kept_texts, tokens
+
+
+# ---------- (a) drop-oldest ----------
+def drop_oldest(turns):
+    keep_n = BUDGET // TOKENS_PER_TURN          # how many turns fit
+    kept = turns[-keep_n:]
+    texts = [t["text"] for t in kept]
+    tokens = len(kept) * TOKENS_PER_TURN
+    return "drop-oldest", texts, tokens, "free, cache-friendly"
+
+
+# ---------- (b) summarize ----------
+def summarize(turns):
+    # Keep the last few verbatim; compress everything older into ONE summary block.
+    keep_verbatim = 4
+    recent = turns[-keep_verbatim:]
+    old = turns[:-keep_verbatim]
+    # Fake summary: a naive summarizer that keeps only "topic" lines and DROPS
+    # the specific account-ID detail (models routinely lose specifics!).
+    summary_text = f"[summary of {len(old)} earlier turns: user discussed various topics]"
+    summary_tokens = 500
+    texts = [summary_text] + [t["text"] for t in recent]
+    tokens = summary_tokens + len(recent) * TOKENS_PER_TURN
+    return "summarize", texts, tokens, "costs an extra LLM call; lossy; cache-hostile"
+
+
+# ---------- (c) retrieve ----------
+def retrieve(turns, query):
+    # Keep the last few verbatim; the REST live in an external store.
+    keep_verbatim = 4
+    recent = turns[-keep_verbatim:]
+    old = turns[:-keep_verbatim]
+    # Fake retriever: pull old turns whose text shares a keyword with the query.
+    # Query "account ID" -> matches the turn that mentions account ID.
+    q_words = {"account", "id"}
+    retrieved = [t for t in old if q_words & set(t["text"].lower().replace("?", "").split())]
+    texts = [f"[retrieved] {t['text']}" for t in retrieved] + [t["text"] for t in recent]
+    tokens = (len(retrieved) + len(recent)) * TOKENS_PER_TURN
+    return "retrieve", texts, tokens, "external store; near-unbounded memory; can miss"
+
+
+# ---------- (d) hybrid / pin ----------
+def hybrid(turns, query):
+    # Pin any turn holding a critical fact (detected here by 'ACC-' marker),
+    # keep last few verbatim, summarize the rest.
+    pinned = [t for t in turns if "ACC-" in t["text"]]
+    recent = turns[-3:]
+    pinned_idx = {t["idx"] for t in pinned}
+    recent_idx = {t["idx"] for t in recent}
+    middle = [t for t in turns if t["idx"] not in pinned_idx and t["idx"] not in recent_idx]
+    summary_text = f"[summary of {len(middle)} middle turns: various topics]"
+    texts = ([f"[PINNED] {t['text']}" for t in pinned]
+             + [summary_text]
+             + [t["text"] for t in recent])
+    tokens = len(pinned) * TOKENS_PER_TURN + 500 + len(recent) * TOKENS_PER_TURN
+    return "hybrid/pin", texts, tokens, "pin + recent + summary; nothing critical at FIFO's mercy"
+
+
+if __name__ == "__main__":
+    turns = build_conversation()
+    total = len(turns) * TOKENS_PER_TURN
+    print("=" * 72)
+    print(f"  20-turn conversation = {total} tokens, but history budget = {BUDGET}")
+    print(f"  Critical fact 'ACC-7788' was set at TURN 2; user asks for it at TURN 20.")
+    print("=" * 72)
+    print()
+
+    results = [
+        drop_oldest(turns),
+        summarize(turns),
+        retrieve(turns, "what was my account ID"),
+        hybrid(turns, "what was my account ID"),
+    ]
+
+    for name, texts, tokens, note in results:
+        has = contains_fact(texts)
+        print(f"POLICY: {name}")
+        print(f"   final history tokens = {tokens:<5} [{fits(tokens)}]   ({note})")
+        print(f"   kept {len(texts)} block(s)")
+        print(f"   >>> critical fact ACC-7788 still reachable? "
+              f"{'YES' if has else 'NO  <-- user gets a wrong/blank answer'}")
+        print()
+
+    print("=" * 72)
+    print("  TAKEAWAY")
+    print("=" * 72)
+    print("  drop-oldest : turn 2 fell off long ago -> fact LOST.")
+    print("  summarize   : naive summary dropped the specific ID -> fact LOST.")
+    print("  retrieve    : fetched exactly the turn with the ID -> fact SURVIVES.")
+    print("  hybrid/pin  : critical fact was pinned -> fact SURVIVES, and it fits.")
+    print()
+    print("  Lesson: 'drop the oldest' is the default and it silently loses")
+    print("  early-established facts. Production pins criticals + retrieves details.")

--- a/llm-context-engineering/constrained.py
+++ b/llm-context-engineering/constrained.py
@@ -1,0 +1,145 @@
+"""
+constrained.py -- Why 'please return JSON' breaks, and how constrained
+decoding fixes it.
+
+Module 02 - Context Engineering, Lesson 6.
+
+Two failure modes of naive "respond only with JSON":
+  1. The model is a probability machine -> sometimes emits fences/preamble/
+     trailing commas -> parse error.
+  2. finish_reason == "length": hitting the token limit mid-object leaves a
+     SYNTAX ERROR, not a slightly-short answer. A fat input context (Lessons
+     1-2) causes this by starving the output budget.
+
+The fix is NOT a better prompt. It's constraining the SAMPLER: at each step,
+compile the schema into a grammar/state-machine, compute which tokens are
+LEGAL next, and mask (zero) every illegal token before sampling. The model
+literally cannot emit invalid JSON.
+
+This is a simulation of that masking behavior in pure Python. Run:
+  python3 constrained.py
+"""
+
+import json
+import random
+
+# A tiny "vocabulary" of output fragments the model might emit each step.
+# Some are junk (fences, preamble, trailing comma) that break JSON parsing.
+JUNK = ["```json", "Sure, here is the JSON:", ",}", "\n\n", "```"]
+
+# The target object we want the model to produce.
+TARGET = {"name": "Alice", "tier": "premium", "open_tickets": 3}
+
+
+# ---------------- unconstrained generation ----------------
+def generate_unconstrained(token_budget, seed):
+    """Free sampling: builds the right JSON but with some probability injects
+    junk tokens, and hard-stops if it exceeds the token budget (finish_reason
+    == length)."""
+    rng = random.Random(seed)
+    out = ""
+    # maybe a preamble (the classic "Sure, here's..." leak)
+    if rng.random() < 0.4:
+        out += rng.choice(["```json\n", "Sure, here is the JSON:\n"])
+    # emit the object piece by piece, char-budgeted
+    body = json.dumps(TARGET)
+    # maybe corrupt with a trailing comma before the closing brace
+    if rng.random() < 0.3:
+        body = body[:-1] + ",}"
+    out += body
+    if rng.random() < 0.3:
+        out += "\n```"
+    # enforce token (char) budget -> truncation
+    finish = "stop"
+    if len(out) > token_budget:
+        out = out[:token_budget]
+        finish = "length"
+    return out, finish
+
+
+# ---------------- constrained generation ----------------
+# A minimal JSON state machine for our fixed schema. At each state only certain
+# next fragments are legal; everything else is masked out (prob -> 0).
+def generate_constrained(token_budget, seed):
+    """Grammar-masked sampling: only legal fragments can be emitted, so the
+    output is always valid + schema-conforming. If the budget is too small the
+    grammar still forces a syntactically-closed object (best effort)."""
+    # The legal, ordered emission plan derived from the schema/state machine.
+    # (In a real system this is computed per-step from the automaton; here we
+    # precompute the only legal path for the fixed schema.)
+    plan = [
+        '{', '"name"', ':', '"Alice"', ',',
+        '"tier"', ':', '"premium"', ',',
+        '"open_tickets"', ':', '3', '}'
+    ]
+    out = ""
+    for frag in plan:
+        # illegal tokens (JUNK) are masked -> can never be chosen. We only ever
+        # append the legal next fragment.
+        if len(out) + len(frag) > token_budget:
+            # forced-close: emit whatever is needed to keep it valid JSON.
+            # close any open string/braces minimally.
+            if not out.endswith("}"):
+                out = out.rstrip(",") 
+                out += "}"
+            return out, "length-but-valid"
+        out += frag
+    return out, "stop"
+
+
+def try_parse(s):
+    try:
+        json.loads(s)
+        return True, ""
+    except Exception as e:
+        return False, str(e)[:50]
+
+
+def trial(label, gen, token_budget, runs=6):
+    print("=" * 72)
+    print(f"  {label}   (token_budget = {token_budget})")
+    print("=" * 72)
+    ok = 0
+    for seed in range(runs):
+        text, finish = gen(token_budget, seed)
+        parsed, err = try_parse(text)
+        ok += parsed
+        shown = text.replace("\n", "\\n")
+        if len(shown) > 46:
+            shown = shown[:46] + "..."
+        status = "PARSES  " if parsed else "BROKEN  "
+        print(f"   seed {seed}: [{status}] finish={finish:<16} {shown}")
+        if not parsed:
+            print(f"            -> parse error: {err}")
+    print(f"   >>> {ok}/{runs} valid JSON")
+    print()
+    return ok, runs
+
+
+if __name__ == "__main__":
+    print("Target object:", json.dumps(TARGET))
+    print()
+
+    # Generous budget: unconstrained still leaks junk sometimes.
+    trial("UNCONSTRAINED ('please return JSON') -- generous budget",
+          generate_unconstrained, token_budget=100)
+
+    # Tight budget: unconstrained hits finish_reason=length -> broken mid-object.
+    trial("UNCONSTRAINED -- TIGHT budget (starved output) -> finish_reason=length",
+          generate_unconstrained, token_budget=20)
+
+    # Constrained decoding: always valid, even under a tight budget.
+    trial("CONSTRAINED (grammar masks illegal tokens) -- generous budget",
+          generate_constrained, token_budget=100)
+
+    trial("CONSTRAINED -- TIGHT budget: still valid (grammar force-closes)",
+          generate_constrained, token_budget=20)
+
+    print("=" * 72)
+    print("  TAKEAWAY")
+    print("=" * 72)
+    print("  - Unconstrained: prompt can't guarantee validity; junk + truncation break it.")
+    print("  - finish_reason=length turns a fat context into BROKEN output (Lessons 1-2).")
+    print("  - Constrained decoding masks illegal tokens -> always parses.")
+    print("  - Still reserve output budget: constraint prevents corruption,")
+    print("    budgeting prevents truncation. You need BOTH.")

--- a/llm-context-engineering/prefix_cache.py
+++ b/llm-context-engineering/prefix_cache.py
@@ -1,0 +1,141 @@
+"""
+prefix_cache.py -- Why prompt LAYOUT decides your bill.
+
+Module 02 - Context Engineering, Lesson 3.
+
+A transformer's KV vectors are causal: a token's K/V depends only on itself and
+the tokens BEFORE it. So the KV of a prefix is a pure function of that prefix.
+=> Compute a prefix's KV once, cache it, reuse it for any request that starts
+   with the same tokens.
+
+The catch: it's a PREFIX cache. It matches left-to-right and stops at the FIRST
+differing token. One volatile token near the FRONT (a timestamp!) invalidates
+everything after it.
+
+Rule: stable content first, volatile content last.
+
+This sim models each request as a list of "blocks" (chunks of tokens). It caches
+blocks by the hash of everything up to and including them (the prefix identity),
+then measures the cached-prefix length request-over-request.
+
+Pure Python. No dependencies. Run:  python3 prefix_cache.py
+"""
+
+import hashlib
+
+# Pricing knobs (illustrative, roughly matching real APIs)
+PRICE_PER_UNCACHED = 3.00 / 1_000_000   # $ per input token, full price
+PRICE_PER_CACHED   = 0.30 / 1_000_000   # $ per input token, cached (10x cheaper)
+
+
+def block_hash(prefix_ids):
+    """Identity of a prefix = hash of the whole token sequence up to here."""
+    return hashlib.sha256(repr(prefix_ids).encode()).hexdigest()[:8]
+
+
+class PrefixCache:
+    def __init__(self):
+        self.seen = set()  # set of prefix-hashes we've already computed KV for
+
+    def process(self, blocks):
+        """
+        blocks: list of (name, token_ids). We walk left-to-right, building the
+        cumulative prefix. A block is a CACHE HIT if the cumulative prefix hash
+        up to and including it was already seen. The first miss breaks the chain
+        (everything after must be recomputed, because its prefix now differs).
+        """
+        cumulative = []
+        cached_tokens = 0
+        computed_tokens = 0
+        still_hitting = True
+        trace = []
+
+        for name, ids in blocks:
+            cumulative += ids
+            h = block_hash(cumulative)
+            if still_hitting and h in self.seen:
+                cached_tokens += len(ids)
+                trace.append(f"   [HIT ] {name:<26} {len(ids):>5} tok  (cached)")
+            else:
+                still_hitting = False
+                computed_tokens += len(ids)
+                self.seen.add(h)
+                trace.append(f"   [miss] {name:<26} {len(ids):>5} tok  (recompute)")
+            # Even on a hit we must register the hash so future longer prefixes match.
+            self.seen.add(h)
+
+        return cached_tokens, computed_tokens, trace
+
+
+def cost(cached, computed):
+    return cached * PRICE_PER_CACHED + computed * PRICE_PER_UNCACHED
+
+
+def run_layout(title, make_blocks, turns):
+    print("=" * 72)
+    print(f"  {title}")
+    print("=" * 72)
+    cache = PrefixCache()
+    total_cached = total_computed = 0
+    for t in range(1, turns + 1):
+        blocks = make_blocks(t)
+        cached, computed, trace = cache.process(blocks)
+        total_cached += cached
+        total_computed += computed
+        hitrate = cached * 100 // (cached + computed)
+        print(f"Turn {t:>2}:  cached={cached:>5}  recompute={computed:>5}  "
+              f"prefix-hit={hitrate:>3}%   turn cost=${cost(cached, computed):.6f}")
+    print("-" * 72)
+    total = total_cached + total_computed
+    print(f"TOTALS:  cached={total_cached}  recompute={total_computed}  "
+          f"overall prefix-hit={total_cached * 100 // total}%")
+    print(f"TOTAL COST over {turns} turns = ${cost(total_cached, total_computed):.6f}")
+    print()
+    return cost(total_cached, total_computed)
+
+
+# --- Content blocks (token counts are illustrative) ---
+SYSTEM = ("system_prompt", list(range(1000, 1000 + 2000)))     # 2000 stable tokens
+def history_block(t):
+    # Each past turn is a stable, unchanging block once it happened.
+    return (f"history_turn_{t:02d}", list(range(9000 + t * 1000, 9000 + t * 1000 + 500)))
+def new_msg(t):
+    return (f"new_user_msg_{t:02d}", list(range(50000 + t * 100, 50000 + t * 100 + 300)))
+def timestamp(t):
+    # A volatile block: different every single request.
+    return (f"timestamp_{t:02d}", [700000 + t])  # 1 token, but it CHANGES each turn
+
+
+def volatile_first(t):
+    """BAD layout: timestamp on TOP, before the stable system prompt."""
+    blocks = [timestamp(t), SYSTEM]
+    for past in range(1, t):
+        blocks.append(history_block(past))
+    blocks.append(new_msg(t))
+    return blocks
+
+
+def stable_first(t):
+    """GOOD layout: stable system prompt first, volatile timestamp at the BOTTOM."""
+    blocks = [SYSTEM]
+    for past in range(1, t):
+        blocks.append(history_block(past))
+    blocks.append(timestamp(t))   # volatile, but at the end -> only it + new msg miss
+    blocks.append(new_msg(t))
+    return blocks
+
+
+if __name__ == "__main__":
+    TURNS = 8
+    c_bad = run_layout("BAD: timestamp on TOP (volatile-first) -- cache keeps breaking",
+                       volatile_first, TURNS)
+    c_good = run_layout("GOOD: timestamp on BOTTOM (stable-first) -- prefix stays cached",
+                        stable_first, TURNS)
+
+    print("=" * 72)
+    print("  VERDICT")
+    print("=" * 72)
+    print(f"volatile-first total cost : ${c_bad:.6f}")
+    print(f"stable-first  total cost  : ${c_good:.6f}")
+    if c_good > 0:
+        print(f"stable-first is {c_bad / c_good:.1f}x cheaper -- SAME tokens, just reordered.")

--- a/llm-context-engineering/rag.py
+++ b/llm-context-engineering/rag.py
@@ -1,0 +1,162 @@
+"""
+rag.py -- RAG done right: chunk -> hybrid (BM25 + vector) -> rerank.
+
+Module 02 - Context Engineering, Lesson 5.
+
+The point of this demo is to show WHY hybrid retrieval beats either method alone:
+  - BM25 (lexical) nails exact tokens (IDs, codes, names) but is blind to meaning.
+  - Vector (semantic) nails paraphrase/synonyms but fumbles exact tokens.
+They fail in OPPOSITE directions, so fusing them wins. Then a reranker does a
+precision pass to keep only the top few for the budget.
+
+Everything here is pure Python (numpy is unavailable). The "embedding" is a toy
+bag-of-concepts vector, NOT a real model -- the goal is the pipeline behavior,
+not embedding quality.
+
+Run:  python3 rag.py
+"""
+
+import math
+import re
+
+# ---------------- corpus ----------------
+DOCS = [
+    "To reset your password, go to Settings and click Credential Recovery.",
+    "Our refund policy allows returns within 30 days of purchase.",
+    "The premium tier costs $20 per month and includes priority support.",
+    "Account ACC-7788 is flagged for manual review by the billing team.",
+    "Automobiles manufactured before 2005 require an emissions inspection.",
+    "To change your login credentials, use the account recovery workflow.",
+    "Account ACC-7799 was closed at the customer's request last week.",
+    "Priority support responds within one hour for premium subscribers.",
+]
+
+# ---------------- tokenization ----------------
+def toks(s):
+    return re.findall(r"[a-z0-9\-]+", s.lower())
+
+# ---------------- BM25 (lexical) ----------------
+def build_bm25(docs):
+    corpus = [toks(d) for d in docs]
+    N = len(corpus)
+    avgdl = sum(len(d) for d in corpus) / N
+    df = {}
+    for d in corpus:
+        for w in set(d):
+            df[w] = df.get(w, 0) + 1
+    idf = {w: math.log(1 + (N - n + 0.5) / (n + 0.5)) for w, n in df.items()}
+    return corpus, avgdl, idf
+
+def bm25_score(query, doc_toks, avgdl, idf, k1=1.5, b=0.75):
+    score = 0.0
+    dl = len(doc_toks)
+    for w in toks(query):
+        if w not in idf:
+            continue
+        f = doc_toks.count(w)
+        if f == 0:
+            continue
+        score += idf[w] * (f * (k1 + 1)) / (f + k1 * (1 - b + b * dl / avgdl))
+    return score
+
+# ---------------- toy "embedding" (semantic) ----------------
+# Map words to a few coarse CONCEPT buckets so paraphrases share a vector.
+CONCEPTS = {
+    "credentials": {"password", "credential", "credentials", "login", "recovery", "reset"},
+    "billing":     {"refund", "returns", "purchase", "billing", "cost", "$20", "premium", "tier"},
+    "support":     {"support", "priority", "responds", "hour", "subscribers"},
+    "vehicle":     {"automobile", "automobiles", "car", "cars", "emissions", "inspection"},
+    "account":     {"account", "acc-7788", "acc-7799", "review", "closed", "flagged"},
+}
+def embed(s):
+    v = {c: 0.0 for c in CONCEPTS}
+    for w in toks(s):
+        for c, words in CONCEPTS.items():
+            if w in words:
+                v[c] += 1.0
+    return v
+def cosine(a, b):
+    dot = sum(a[c] * b[c] for c in a)
+    na = math.sqrt(sum(x * x for x in a.values()))
+    nb = math.sqrt(sum(x * x for x in b.values()))
+    return dot / (na * nb) if na and nb else 0.0
+
+# ---------------- retrieval methods ----------------
+def normalize(scores):
+    m = max(scores) if scores else 0
+    return [s / m if m else 0 for s in scores]
+
+def retrieve(query, corpus, avgdl, idf):
+    bm = [bm25_score(query, d, avgdl, idf) for d in corpus]
+    qv = embed(query)
+    vec = [cosine(qv, embed(DOCS[i])) for i in range(len(DOCS))]
+    return normalize(bm), normalize(vec)
+
+def rerank(query, candidates):
+    """Toy cross-encoder: score each candidate by joint keyword+concept overlap
+    seen TOGETHER with the query. Rewards docs that match BOTH lexically and
+    semantically -- the precision pass."""
+    qwords = set(toks(query))
+    qv = embed(query)
+    scored = []
+    for i in candidates:
+        lex = len(qwords & set(toks(DOCS[i])))
+        sem = cosine(qv, embed(DOCS[i]))
+        scored.append((lex + 2 * sem, i))
+    scored.sort(reverse=True)
+    return [i for _, i in scored]
+
+def show(title, ranked, k=3):
+    print(f"   {title}:")
+    for i in ranked[:k]:
+        print(f"      #{i}: {DOCS[i]}")
+
+
+def run_query(query, corpus, avgdl, idf, want_idx, label):
+    print("=" * 74)
+    print(f"  QUERY: {query!r}")
+    print(f"  ({label}; the ideal answer is doc #{want_idx})")
+    print("=" * 74)
+    bm, vec = retrieve(query, corpus, avgdl, idf)
+
+    bm_rank = sorted(range(len(DOCS)), key=lambda i: bm[i], reverse=True)
+    vec_rank = sorted(range(len(DOCS)), key=lambda i: vec[i], reverse=True)
+    fused = [0.5 * bm[i] + 0.5 * vec[i] for i in range(len(DOCS))]
+    fused_rank = sorted(range(len(DOCS)), key=lambda i: fused[i], reverse=True)
+    reranked = rerank(query, fused_rank[:5])   # wide net (5) -> precise top
+
+    show("BM25-only  (lexical)", bm_rank)
+    show("Vector-only (semantic)", vec_rank)
+    show("Hybrid (fused)", fused_rank)
+    show("Hybrid + rerank", reranked)
+
+    def hit(rank): return "YES" if want_idx in rank[:3] else "NO "
+    print()
+    print(f"   got doc #{want_idx} in top-3?   "
+          f"BM25={hit(bm_rank)}  Vector={hit(vec_rank)}  "
+          f"Hybrid={hit(fused_rank)}  Hybrid+rerank={hit(reranked)}")
+    print()
+
+
+if __name__ == "__main__":
+    corpus, avgdl, idf = build_bm25(DOCS)
+
+    # Query A: needs MEANING. "how do I change my password" shares NO exact words
+    # with doc #5 ("change your login credentials") beyond 'change'/'your'.
+    run_query("how do I recover my forgotten password",
+              corpus, avgdl, idf, want_idx=0,
+              label="paraphrase: 'password/recover' vs 'Credential Recovery'")
+
+    # Query B: needs EXACT TOKEN. The literal ID must not be confused with a
+    # semantically-identical neighbor (ACC-7799).
+    run_query("what is the status of account ACC-7788",
+              corpus, avgdl, idf, want_idx=3,
+              label="exact ID: ACC-7788 must not be confused with ACC-7799")
+
+    print("=" * 74)
+    print("  TAKEAWAY")
+    print("=" * 74)
+    print("  - Semantic query: vector shines, BM25 can miss (no shared keywords).")
+    print("  - Exact-ID query: BM25 shines, vector can confuse ACC-7788 vs ACC-7799.")
+    print("  - Hybrid catches BOTH; rerank puts the single best doc on top.")
+    print("  Vector-only is the common beginner mistake. Real RAG is hybrid + rerank.")


### PR DESCRIPTION
Adds the 5 runnable context-engineering demos (budget.py, prefix_cache.py, compress.py, rag.py, constrained.py) under llm-context-engineering/, peer to the inference simulator. Referenced by the context-engineering blog post.